### PR TITLE
Add Ruby 1.8 support

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -84,7 +84,8 @@ module SitePrism::ElementContainer
         raise SitePrism::NoLocatorForElement.new("#{self.class.name} => :#{element_name} needs a locator")
       end
     else
-      define_method method_name do |timeout = Capybara.default_wait_time|
+      define_method method_name do |*args|
+        timeout = args.shift || Capybara.default_wait_time
         Capybara.using_wait_time timeout do
           element_waiter element_locator
         end


### PR DESCRIPTION
Small tweak to fix Ruby 1.8 compatibility (_using Ruby 1.9's default block arguments breaks support for Ruby 1.8_)
