### PR TITLE
Added xpath and capybara selector options support

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -1,34 +1,34 @@
 module SitePrism::ElementContainer
 
-  def element element_name, element_selector = nil
-    build element_name, element_selector do
+  def element element_name, *q 
+    build element_name, *q do
       define_method element_name.to_s do
-        find_first element_selector
+        find_first *q
       end
     end
   end
 
-  def elements collection_name, collection_selector = nil
-    build collection_name, collection_selector do
+  def elements collection_name, *q
+    build collection_name, *q do
       define_method collection_name.to_s do
-        find_all collection_selector
+        find_all *q
       end
     end
   end
   alias :collection :elements
 
-  def section section_name, section_class, section_selector
-    build section_name, section_selector do
+  def section section_name, section_class, *q
+    build section_name, *q do
       define_method section_name do
-        section_class.new find_first section_selector
+        section_class.new find_first *q
       end
     end
   end
 
-  def sections section_collection_name, section_class, section_collection_selector
-    build section_collection_name, section_collection_selector do
+  def sections section_collection_name, section_class, *q
+    build section_collection_name, *q do
       define_method section_collection_name do
-        find_all(section_collection_selector).collect do |element|
+        find_all(*q).collect do |element|
           section_class.new element
         end
       end
@@ -57,73 +57,73 @@ module SitePrism::ElementContainer
 
   private
   
-  def build name, selector
-    if selector.nil?
+  def build name, *q
+    if q.length == 0
       create_no_selector name
     else
       add_to_mapped_items name
       yield
     end
-    add_checkers_and_waiters name, selector
+    add_checkers_and_waiters name, *q
   end
   
-  def add_checkers_and_waiters name, selector
-    create_existence_checker name, selector
-    create_waiter name, selector
-    create_visibility_waiter name, selector
-    create_invisibility_waiter name, selector
+  def add_checkers_and_waiters name, *q
+    create_existence_checker name, *q
+    create_waiter name, *q
+    create_visibility_waiter name, *q
+    create_invisibility_waiter name, *q
   end
   
-  def build_checker_or_waiter element_name, proposed_method_name, selector
-    if selector.nil?
+  def build_checker_or_waiter element_name, proposed_method_name, *q
+    if q.length == 0
       create_no_selector element_name, proposed_method_name
     else
       yield
     end
   end
 
-  def create_existence_checker element_name, element_selector
+  def create_existence_checker element_name, *q
     method_name = "has_#{element_name.to_s}?"
-    build_checker_or_waiter element_name, method_name, element_selector do
+    build_checker_or_waiter element_name, method_name, *q do
       define_method method_name do
         Capybara.using_wait_time 0 do
-          element_exists? element_selector
+          element_exists? *q
         end
       end
     end
   end
 
-  def create_waiter element_name, element_selector
+  def create_waiter element_name, *q
     method_name = "wait_for_#{element_name.to_s}"
-    build_checker_or_waiter element_name, method_name, element_selector do
+    build_checker_or_waiter element_name, method_name, *q do
       define_method method_name do |timeout = Capybara.default_wait_time|
         Capybara.using_wait_time timeout do
-          element_exists? element_selector
+          element_exists? *q
         end
       end
     end
   end
 
-  def create_visibility_waiter element_name, element_selector
+  def create_visibility_waiter element_name, *q
     method_name = "wait_until_#{element_name.to_s}_visible"
-    build_checker_or_waiter element_name, method_name, element_selector do
+    build_checker_or_waiter element_name, method_name, *q do
       define_method method_name do |timeout = Capybara.default_wait_time|
         Capybara.using_wait_time timeout do
-          element_exists? element_selector
+          element_exists? *q
         end
         Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
-          sleep 0.1 until find_first(element_selector).visible?
+          sleep 0.1 until find_first(*q).visible?
         end
       end
     end
   end
 
-  def create_invisibility_waiter element_name, element_selector
+  def create_invisibility_waiter element_name, *q
     method_name = "wait_until_#{element_name.to_s}_invisible"
-    build_checker_or_waiter element_name, method_name, element_selector do
+    build_checker_or_waiter element_name, method_name, *q do
       define_method method_name do |timeout = Capybara.default_wait_time|
         Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
-          sleep 0.1 while element_exists?(element_selector) && find_first(element_selector).visible?
+          sleep 0.1 while element_exists?(*q) && find_first(*q).visible?
         end
       end
     end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -49,16 +49,16 @@ module SitePrism
 
     private
 
-    def find_first selector
-      first selector
+    def find_first *q
+      first *q
     end
 
-    def find_all selector
-      all selector
+    def find_all *q
+      all *q
     end
 
-    def element_exists? selector
-      has_selector? selector
+    def element_exists? *q
+      has_selector? *q
     end
   end
 end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -24,16 +24,16 @@ module SitePrism
 
     private
 
-    def find_first selector
-      root_element.first selector
+    def find_first *q
+      root_element.first *q
     end
 
-    def find_all selector
-      root_element.all selector
+    def find_all *q
+      root_element.all *q
     end
 
-    def element_exists? selector
-      root_element.has_selector? selector
+    def element_exists? *q
+      root_element.has_selector? *q
     end
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -36,5 +36,38 @@ describe SitePrism::Page do
     page = PageWithAFewElements.new
     page.should respond_to :all_there?
   end
+
+  it "element method with xpath should generate existence check method" do
+    class PageWithElement < SitePrism::Page
+      element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
+    end
+    page = PageWithElement.new
+    page.should respond_to :has_bob?
+  end
+
+  it "element method with xpathshould generate method to return the element" do
+    class PageWithElement < SitePrism::Page
+      element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
+    end
+    page = PageWithElement.new
+    page.should respond_to :bob
+  end
+
+  it "should be able to wait for an element defined with xpath selector" do
+    class PageWithElement < SitePrism::Page
+      element :some_slow_element, :xpath, '//a[@class="slow"]'
+    end
+    page = PageWithElement.new
+    page.should respond_to :wait_for_some_slow_element
+  end
+
+  it "should know if all mapped elements defined by xpath selector are on the page" do
+    class PageWithAFewElements < SitePrism::Page
+      element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
+    end
+    page = PageWithAFewElements.new
+    page.should respond_to :all_there?
+  end
+
 end
 

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -3,17 +3,17 @@ class TestHomePage < SitePrism::Page
   set_url_matcher /home\.htm$/
 
   #individual elements
-  element :welcome_header, 'h1'
-  element :welcome_message, 'span'
-  element :go_button, 'input'
-  element :link_to_search_page, 'a'
-  element :some_slow_element, 'a.slow'
+  element :welcome_header, :xpath, '//h1'
+  element :welcome_message, :xpath, '//span'
+  element :go_button, :xpath, '//input'
+  element :link_to_search_page, :xpath, '//a'
+  element :some_slow_element, :xpath, '//a[@class="slow"]'
   element :invisible_element, 'input.invisible'
   element :shy_element, 'input#will_become_visible'
   element :retiring_element, 'input#will_become_invisible'
 
   #element groups
-  elements :lots_of_links, 'td a'
+  elements :lots_of_links, :xpath, '//td//a'
 
   #elements that should not exist
   element :squirrel, 'squirrel.nutz'


### PR DESCRIPTION
I have added support for xpath and other capybara selector options. In short element(s) can be defined like these.

element :some_element, :xpath, "//div[@class='a']"
element :another, "a.b", {:visible => true}

This was desirable in the project I am currently working on. I am sure, others can also benefit from this. I will appreciate your input on these updates. Thanks.
