### PR TITLE
Enabling the Capybara 2.1 match disambiguation strategy and first_first behaviour

### DIFF
--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -54,7 +54,7 @@ module SitePrism
       if !Capybara.methods.include?(:match)
         begin
           find *find_args
-        rescue Capybara::ElementNotFound
+        rescue Capybara::Ambiguous
           first *find_args
         end
       else

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -37,7 +37,7 @@ module SitePrism
       if !Capybara.methods.include?(:match)
         begin
           root_element.find *find_args
-        rescue Capybara::ElementNotFound
+        rescue Capybara::Ambiguous
           root_element.first *find_args
         end
       else


### PR DESCRIPTION
Now this is a proper pull request with the replacement on the find_first method to use find in replacement of first and also be aware of the Capybara 2.1 match disambiguation strategy.
