### PR TITLE
Add #go method for chainable navigation

### DIFF
--- a/features/messages.feature
+++ b/features/messages.feature
@@ -1,0 +1,10 @@
+Feature: Page navigation
+  As a tester
+  I want to be able to use abstractions for messages on the page
+  In order to verify the page
+
+  Scenario: Verify a message
+    When I navigate to the message page
+    Then I should see the greeting message
+     But I should not see the thank you message
+

--- a/features/navigation.feature
+++ b/features/navigation.feature
@@ -1,12 +1,13 @@
 Feature: Page navigation
-	As a tester
-	I want to be able to point my test at a page
-	In order to interact with it
+  As a tester
+  I want to be able to point my test at a page
+  In order to interact with it
 
-	Scenario: Navigate to a page
-		When I navigate to the home page
-		Then I am on the home page
+  Scenario: Navigate to a page
+    When I navigate to the home page
+    Then I am on the home page
 
-	Scenario: Navigate to a dynamic page
-		When I navigate to the letter A page
-		Then I am on a dynamic page
+  Scenario: Navigate to a dynamic page
+    When I navigate to the letter A page
+    Then I am on a dynamic page
+

--- a/features/step_definitions/message_steps.rb
+++ b/features/step_definitions/message_steps.rb
@@ -1,0 +1,12 @@
+When /^I navigate to the message page$/ do
+  @test_site = TestSite.new
+  @test_site.page_with_message.load
+end
+
+Then /^I should see the greeting message$/ do
+  @test_site.page_with_message.should have_greeting
+end
+
+Then /^I should not see the thank you message$/ do
+  @test_site.page_with_message.should have_no_thank_you
+end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -29,3 +29,11 @@ When /^I navigate to the section experiments page$/ do
   @test_site.section_experiments.load
 end
 
+When(/^I go do something on the home page$/) do
+  @home_page = TestSite.new.home
+  @home_page.go.do_something
+end
+
+Then(/^the text field on the home page is filled$/) do
+  @home_page.some_text_field.value.should == 'foobar'
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,6 +24,7 @@ require 'pages/home'
 require 'pages/dynamic_page'
 require 'pages/no_title'
 require 'pages/page_with_people'
+require 'pages/page_with_message'
 require 'pages/section_experiments'
 
 Capybara.configure do |config|

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -3,6 +3,7 @@ require 'site_prism/version'
 require 'site_prism/exceptions'
 require 'site_prism/element_container'
 require 'site_prism/element_checker'
+require 'site_prism/message_container'
 require 'site_prism/page'
 require 'site_prism/section'
 

--- a/lib/site_prism/message_container.rb
+++ b/lib/site_prism/message_container.rb
@@ -1,0 +1,41 @@
+module SitePrism::MessageContainer
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def message(message_name, message_key)
+      define_method message_name do
+        if message_translator
+          message_translator.call(message_key)
+        else
+          message_key.gsub(/[._]/,' ')
+        end
+      end
+
+      define_method "has_#{message_name.to_s}?" do
+        Capybara.using_wait_time 0 do
+          message_exists? send(message_name)
+        end
+      end
+
+      define_method "has_no_#{message_name.to_s}?" do
+        Capybara.using_wait_time 0 do
+          message_does_not_exist? send(message_name)
+        end
+      end
+    end
+
+    def set_message_translator(&block)
+      @message_translator = block
+    end
+
+    def message_translator
+      @message_translator
+    end
+  end
+
+  def message_translator
+    self.class.message_translator
+  end
+end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -10,6 +10,11 @@ module SitePrism
       visit expanded_url
     end
 
+    def go(*args)
+      load *args
+      self
+    end
+
     def displayed?
       raise SitePrism::NoUrlMatcherForPage if url_matcher.nil?
       !(page.current_url =~ url_matcher).nil?

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -3,6 +3,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     extend ElementContainer
+    include MessageContainer
 
     def load(expansion = {})
       expanded_url = url(expansion)
@@ -65,6 +66,14 @@ module SitePrism
 
     def element_does_not_exist? *find_args
       has_no_selector? *find_args
+    end
+
+    def message_exists?(text)
+      has_text? text
+    end
+
+    def message_does_not_exist?(text)
+      has_no_text? text
     end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+class PageWithMessage < SitePrism::Page
+  message :thank_you_message, 'some.msg.key'
+end
+
+describe SitePrism::Page do
+  it "should respond to message" do
+    SitePrism::Page.should respond_to :message
+  end
+
+  it "should set a method translator" do
+    SitePrism::Page.should respond_to :set_message_translator
+  end
+
+  it "should define a method for the message" do
+    PageWithMessage.new.should respond_to(:thank_you_message)
+  end
+
+  it "should define a matcher for the message existence" do
+    PageWithMessage.new.should respond_to(:has_thank_you_message?)
+  end
+
+  it "should define a matcher for the message non-existence" do
+    PageWithMessage.new.should respond_to(:has_no_thank_you_message?)
+  end
+
+  it "should return a translated message if there is a translator" do
+    class PageWithTranslator < SitePrism::Page
+      set_message_translator { |key| {'foo' => 'good', 'bar' => 'bad'}.fetch(key) }
+      message :good_message, 'foo'
+    end
+    page = PageWithTranslator.new
+    page.good_message.should == 'good'
+  end
+
+  it "should return the message key humanized if there is no translator" do
+    class PageWithNoTranslator < SitePrism::Page
+      message :good_message, 'foo.bar_baz'
+    end
+    page = PageWithNoTranslator.new
+    page.good_message.should == 'foo bar baz'
+  end
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -5,6 +5,20 @@ describe SitePrism::Page do
     SitePrism::Page.new.should respond_to :load
   end
 
+  describe '#go' do
+    it "delegates to load" do
+      page = SitePrism::Page.new
+      page.should_receive(:load)
+      page.go
+    end
+
+    it "allows chaining" do
+      page = SitePrism::Page.new
+      page.stub(:load)
+      page.go.should == page
+    end
+  end
+
   it "should respond to set_url" do
     SitePrism::Page.should respond_to :set_url
   end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -33,7 +33,10 @@
 		<p>
 			<input type='button' value='Go!'/>
 		</p>
-		<p>
+    <p>
+      <input type='text' id='fill_me_in' value=''/>
+    </p>
+    <p>
 			<a href='search.htm'>Search Page</a>
 		</p>
 		<p>

--- a/test_site/html/page_with_message.htm
+++ b/test_site/html/page_with_message.htm
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Page with Message</title>
+  </head>
+  <body>
+    hey
+    hi there
+    some other text
+  </body>
+</html>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -12,6 +12,7 @@ class TestHomePage < SitePrism::Page
   element :shy_element, 'input#will_become_visible'
   element :retiring_element, 'input#will_become_invisible'
   element :remove_container_with_element_btn, 'input#remove_container_with_element'
+  element :some_text_field, 'input#fill_me_in'
 
   #elements groups
   elements :lots_of_links, :xpath, '//td//a'
@@ -30,5 +31,10 @@ class TestHomePage < SitePrism::Page
 
   #iframes
   iframe :my_iframe, MyIframe, '#the_iframe'
+
+  def do_something
+    # interact with elements...
+    some_text_field.set 'foobar'
+  end
 end
 

--- a/test_site/pages/page_with_message.rb
+++ b/test_site/pages/page_with_message.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+class TestPageWithMessage < SitePrism::Page
+  set_url '/page_with_message.htm'
+
+  #messages
+  set_message_translator do |key|
+    messages = {
+      :en => {
+        'hi.there' => "hi there",
+        'sign_up.thank_you' => 'thanks for joining'
+      },
+      :pt => {
+        'hi.there' => "oi lá",
+        'sign_up.thank_you' => 'obrigado por se juntar'
+      }
+    }
+    messages[:en].fetch(key)
+  end
+
+  message :greeting, 'hi.there'
+  message :thank_you, 'sign_up.thank_you'
+end
+

--- a/test_site/test_site.rb
+++ b/test_site/test_site.rb
@@ -15,6 +15,10 @@ class TestSite
     TestPageWithPeople.new
   end
 
+  def page_with_message
+    TestPageWithMessage.new
+  end
+
   def section_experiments
     TestSectionExperiments.new
   end


### PR DESCRIPTION
The new #go method allows a user to load the page
and interact with it in a single line step body.

Instead of:
my_page.load
my_page.do_something

You can do:
my_page.go.do_something