### PR TITLE
Convert page_url to string on set

### DIFF
--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -16,7 +16,7 @@ module SitePrism
     end
 
     def self.set_url page_url
-      @url = page_url
+      @url = page_url.to_s
     end
 
     def self.set_url_matcher page_url_matcher


### PR DESCRIPTION
Allows any class that responds to to_s to be used as a url path. Since the code expects this to be a String, converting it beforehand allows some of our use case (using Pathname for complicated set_url calls)
