### PR TITLE
Fix an issue in which passing nil to #wait_for_elements causes an error.

### DIFF
--- a/features/page_elements_interaction.feature
+++ b/features/page_elements_interaction.feature
@@ -16,3 +16,7 @@ Feature: Interaction with groups of elements
     When I navigate to the home page
     Then the page does not have elements
 
+  Scenario: Waiting on a set of elements
+    When I navigate to the home page
+    Then I can wait a variable time for elements to appear
+    Then I can wait a variable time and pass specific parameters

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -133,3 +133,16 @@ Then /^I receive an error when a section with the element I am waiting for is re
   expect {@test_site.home.container_with_element.wait_until_embedded_element_invisible}.to raise_error Capybara::ElementNotFound
 end
 
+Then /^I can wait a variable time for elements to appear$/ do
+  @test_site.home.wait_for_lots_of_links
+  @test_site.home.wait_for_lots_of_links(0.1)
+end
+
+Then /^I can wait a variable time and pass specific parameters$/ do
+  @test_site.home.wait_for_lots_of_links(0.1, count: 2)
+  Capybara.using_wait_time 0.3 do
+    # intentionally wait and pass nil to force this to cycle
+    expect(@test_site.home.wait_for_lots_of_links(nil, count: 19810814)).to be_false
+  end
+end
+

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -114,7 +114,8 @@ module SitePrism::ElementContainer
   def create_waiter(element_name, *find_args)
     method_name = "wait_for_#{element_name.to_s}"
     create_helper_method method_name, *find_args do
-      define_method method_name do |timeout = Capybara.default_wait_time, *runtime_args|
+      define_method method_name do |timeout = nil, *runtime_args|
+        timeout = timeout.nil? ? Capybara.default_wait_time : timeout
         Capybara.using_wait_time timeout do
           element_exists? *find_args, *runtime_args
         end


### PR DESCRIPTION
- Capybara expects a float, not nil.

As called out in the readme, this should work:
`@page.wait_for_foobar nil, count: 42`

```
@results_page = SearchResults.new
# ...
@results_page.has_search_results? :count => 25
# OR
@results_page.search_results :count => 25
# OR
@results_page.wait_for_search_results nil, :count => 25 # wait_for_<element_name> expects a timeout value to be passed as the first parameter or nil to use the default timeout value.
```

We were actually passing nil as the timeout though, which worked as long as it didn't actually have to wait for the element.  In that case you'd get:

```
      comparison of Float with nil failed (ArgumentError)
      ./lib/site_prism/page.rb:64:in `element_exists?'
```

So I'm defaulting it to the Capybara.default_wait_time if nil is passed.  I think that's the expected behavior here.  In general I don't like that and think we ought to key all values, but this follows what's in the current readme.

Tests:

```

  Scenario: Waiting on a set of elements                         # features/page_elements_interaction.feature:19
    When I navigate to the home page                             # features/step_definitions/navigation_steps.rb:1
    Then I can wait a variable time for elements to appear       # features/step_definitions/page_element_interaction_steps.rb:136
    Then I can wait a variable time and pass specific parameters # features/step_definitions/page_element_interaction_steps.rb:141

4 scenarios (4 passed)
10 steps (10 passed)
0m2.749s
```
