### PR TITLE
allow block syntax on sections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,9 +7,6 @@ Documentation:
 AccessorMethodName:
   Enabled: false
 
-Style/SymbolProc:
-  Enabled: false
-
 TrivialAccessors:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Documentation:
 AccessorMethodName:
   Enabled: false
 
+Style/SymbolProc:
+  Enabled: false
+
 TrivialAccessors:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -868,10 +868,10 @@ Some of this test code can be made a little prettier by simply passing a block i
 ```ruby
 Then /^the home page menu contains a link to the various search functions$/ do
   @home.menu do |menu|
-    menu.should have_search
-    menu.search['href'].should include "google.com"
-    menu.should have_images
-    menu.should have_maps
+    expect(menu).to have_search
+    expect(menu.search['href']).to include "google.com"
+    expect(menu).to have_images
+    expect(menu).to have_maps
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -860,6 +860,21 @@ Then /^the home page menu contains a link to the various search functions$/ do
 end
 ```
 
+##### Accessing section elements in a block using `within`
+
+Sections have a `within` method that allows scoped access to the section's elements inside a block.  This is similar to Capybara's `within` method and allows for shorter test code particularly with nested sections.
+
+```ruby
+Then /^the home page menu contains a link to the various search functions$/ do
+  @home.menu.within do |submenu|
+    menu.should have_search
+    menu.search['href'].should include "google.com"
+    menu.should have_images
+    menu.should have_maps
+  end
+end
+```
+
 #### Getting a section's parent
 
 It is possible to ask a section for its parent (page, or section if this

--- a/README.md
+++ b/README.md
@@ -860,13 +860,14 @@ Then /^the home page menu contains a link to the various search functions$/ do
 end
 ```
 
-##### Accessing section elements in a block using `within`
+##### Accessing section elements using a block
 
 Sections have a `within` method that allows scoped access to the section's elements inside a block.  This is similar to Capybara's `within` method and allows for shorter test code particularly with nested sections.
+Some of this test code can be made a little prettier by simply passing a block in.
 
 ```ruby
 Then /^the home page menu contains a link to the various search functions$/ do
-  @home.menu.within do |submenu|
+  @home.menu do |menu|
     menu.should have_search
     menu.search['href'].should include "google.com"
     menu.should have_images

--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -9,7 +9,7 @@ Feature: Page Sections
     When I navigate to another page
     Then that section is there too
 
-  Scenario: access elements in the section by passing a block to #within
+  Scenario: access elements in the section by passing a block
     When I navigate to the home page
     Then I can access elements within the section using a block
 
@@ -20,6 +20,10 @@ Feature: Page Sections
   Scenario: section within a section using blocks
     When I navigate to the section experiments page
     Then I can see a section within a section using nested blocks
+
+  Scenario: section scoping
+    When I navigate to the home page
+    Then access to elements is constrained to those within the section
 
   Scenario: collection of sections
     When I navigate to the section experiments page

--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -9,9 +9,17 @@ Feature: Page Sections
     When I navigate to another page
     Then that section is there too
 
-  Scenario: section within a section
+  Scenario: access elements in the section by passing a block to #within
+    When I navigate to the home page
+    Then I can access elements within the section using a block
+
+  Scenario: section in a section
     When I navigate to the section experiments page
-    Then I can see a section within a section
+    Then I can see a section in a section
+
+  Scenario: section within a section using blocks
+    When I navigate to the section experiments page
+    Then I can see a section within a section using nested blocks
 
   Scenario: collection of sections
     When I navigate to the section experiments page
@@ -64,7 +72,7 @@ Feature: Page Sections
 
   Scenario: Page with no section
     When I navigate to the home page
-    Then the page does not have section
+    Then the page does not have a section
 
   Scenario: Page with section that does not contain element
     When I navigate to the home page

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -4,7 +4,11 @@ Then(/^I can see elements in the section$/) do
   expect(@test_site.home.people).to have_headline text: 'People'
 end
 
-Then /^I can access elements within the section using a block$/ do
+Then(/^I can see a section in a section$/) do
+  expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label text: 'something'
+end
+
+Then(/^I can access elements within the section using a block$/) do
   expect(@test_site.home).to have_people
   @test_site.home.people do |persons|
     expect(persons).to have_headline text: 'People'
@@ -16,20 +20,20 @@ Then /^I can access elements within the section using a block$/ do
   # the above would pass if the block were ignored, this verifies it is executed:
   expect do
     @test_site.home.people { |p| expect(p).to have_dinosaur }
-  end.to raise_error
+  end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 
-Then /^access to elements is constrained to those within the section$/ do
+Then(/^access to elements is constrained to those within the section$/) do
   @test_site.home.should have_css('span.welcome')
   @test_site.home.people do |persons|
     persons.should have_no_css('.welcome')
-    expect{ persons.has_welcome_message? }.to raise_error(NoMethodError)
+    expect { persons.has_welcome_message? }.to raise_error(NoMethodError)
     expect(persons).to have_no_welcome_message_on_the_parent
   end
 end
 
-Then /^the page does not have a section$/ do
-  @test_site.home.has_no_nonexistent_section?
+Then(/^the page does not have a section$/) do
+  expect(@test_site.home.has_no_nonexistent_section?).to be_truthy
   expect(@test_site.home).to have_no_nonexistent_section
 end
 
@@ -46,19 +50,19 @@ Then(/^I can see a section within a section$/) do
   expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label text: 'something'
 end
 
-Then /^I can see a section within a section using nested blocks$/ do
+Then(/^I can see a section within a section using nested blocks$/)do
   @test_site.section_experiments.should have_parent_section
   @test_site.section_experiments.parent_section do |parent|
-    parent.should have_child_section
-    parent.child_section.nice_label.text.should == "something"
+    expect(parent).to have_child_section
+    expect(parent.child_section.nice_label.text).to eq 'something'
     parent.child_section do |child|
-      child.should have_nice_label :text => "something"
+      expect(child).to have_nice_label text: 'something'
     end
   end
 end
 
-Then /^I can see a collection of sections$/ do
-  @test_site.section_experiments.should have_search_results
+Then(/^I can see a collection of sections$/) do
+  expect(@test_site.section_experiments).to have_search_results
   @test_site.section_experiments.search_results.each_with_index do |search_result, i|
     expect(search_result.title.text).to eq "title #{i}"
     expect(search_result.link.text).to eq "link #{i}"

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -15,8 +15,8 @@ Then(/^I can access elements within the section using a block$/) do
     expect(persons.headline.text).to eq 'People'
     expect(persons).to have_no_dinosaur
     expect(persons).to have_individuals count: 4
-
   end
+
   # the above would pass if the block were ignored, this verifies it is executed:
   expect do
     @test_site.home.people { |p| expect(p).to have_dinosaur }
@@ -24,9 +24,9 @@ Then(/^I can access elements within the section using a block$/) do
 end
 
 Then(/^access to elements is constrained to those within the section$/) do
-  @test_site.home.should have_css('span.welcome')
+  expect(@test_site.home).to have_css('span.welcome')
   @test_site.home.people do |persons|
-    persons.should have_no_css('.welcome')
+    expect(persons).to have_no_css('.welcome')
     expect { persons.has_welcome_message? }.to raise_error(NoMethodError)
     expect(persons).to have_no_welcome_message_on_the_parent
   end
@@ -51,7 +51,7 @@ Then(/^I can see a section within a section$/) do
 end
 
 Then(/^I can see a section within a section using nested blocks$/)do
-  @test_site.section_experiments.should have_parent_section
+  expect(@test_site.section_experiments).to have_parent_section
   @test_site.section_experiments.parent_section do |parent|
     expect(parent).to have_child_section
     expect(parent.child_section.nice_label.text).to eq 'something'

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -5,12 +5,26 @@ Then(/^I can see elements in the section$/) do
 end
 
 Then /^I can access elements within the section using a block$/ do
-  @test_site.home.should have_people
-  @test_site.home.people.within do |persons|
-    expect(persons).to have_title text: 'People'
-    expect(persons.title.text).to eq 'People'
+  expect(@test_site.home).to have_people
+  @test_site.home.people do |persons|
+    expect(persons).to have_headline text: 'People'
+    expect(persons.headline.text).to eq 'People'
     expect(persons).to have_no_dinosaur
     expect(persons).to have_individuals count: 4
+
+  end
+  # the above would pass if the block were ignored, this verifies it is executed:
+  expect do
+    @test_site.home.people { |p| expect(p).to have_dinosaur }
+  end.to raise_error
+end
+
+Then /^access to elements is constrained to those within the section$/ do
+  @test_site.home.should have_css('span.welcome')
+  @test_site.home.people do |persons|
+    persons.should have_no_css('.welcome')
+    expect{ persons.has_welcome_message? }.to raise_error(NoMethodError)
+    expect(persons).to have_no_welcome_message_on_the_parent
   end
 end
 
@@ -34,10 +48,10 @@ end
 
 Then /^I can see a section within a section using nested blocks$/ do
   @test_site.section_experiments.should have_parent_section
-  @test_site.section_experiments.parent_section.within do |parent|
+  @test_site.section_experiments.parent_section do |parent|
     parent.should have_child_section
     parent.child_section.nice_label.text.should == "something"
-    parent.child_section.within do |child|
+    parent.child_section do |child|
       child.should have_nice_label :text => "something"
     end
   end

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -4,7 +4,17 @@ Then(/^I can see elements in the section$/) do
   expect(@test_site.home.people).to have_headline text: 'People'
 end
 
-Then(/^the page does not have section$/) do
+Then /^I can access elements within the section using a block$/ do
+  @test_site.home.should have_people
+  @test_site.home.people.within do |persons|
+    expect(persons).to have_title text: 'People'
+    expect(persons.title.text).to eq 'People'
+    expect(persons).to have_no_dinosaur
+    expect(persons).to have_individuals count: 4
+  end
+end
+
+Then /^the page does not have a section$/ do
   @test_site.home.has_no_nonexistent_section?
   expect(@test_site.home).to have_no_nonexistent_section
 end
@@ -22,8 +32,19 @@ Then(/^I can see a section within a section$/) do
   expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label text: 'something'
 end
 
-Then(/^I can see a collection of sections$/) do
-  expect(@test_site.section_experiments).to have_search_results
+Then /^I can see a section within a section using nested blocks$/ do
+  @test_site.section_experiments.should have_parent_section
+  @test_site.section_experiments.parent_section.within do |parent|
+    parent.should have_child_section
+    parent.child_section.nice_label.text.should == "something"
+    parent.child_section.within do |child|
+      child.should have_nice_label :text => "something"
+    end
+  end
+end
+
+Then /^I can see a collection of sections$/ do
+  @test_site.section_experiments.should have_search_results
   @test_site.section_experiments.search_results.each_with_index do |search_result, i|
     expect(search_result.title.text).to eq "title #{i}"
     expect(search_result.link.text).to eq "link #{i}"

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -1,3 +1,4 @@
+# rubocop:disable ModuleLength
 module SitePrism
   module ElementContainer
     attr_reader :mapped_items

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -24,7 +24,7 @@ module SitePrism
     def section(section_name, *args, &block)
       section_class, find_args = extract_section_options args, &block
       build section_name, *find_args do
-        define_method section_name do | *runtime_args, &runtime_block |
+        define_method section_name do |*runtime_args, &runtime_block|
           section_class.new self, find_first(*find_args, *runtime_args), &runtime_block
         end
       end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -1,4 +1,3 @@
-# rubocop:disable ModuleLength
 module SitePrism
   module ElementContainer
     attr_reader :mapped_items

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -24,9 +24,8 @@ module SitePrism
     def section(section_name, *args, &block)
       section_class, find_args = extract_section_options args, &block
       build section_name, *find_args do
-        define_method section_name do |*runtime_args, &element_block|
-          self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
-          section_class.new self, find_first(*find_args, *runtime_args)
+        define_method section_name do | *runtime_args, &runtime_block |
+          section_class.new self, find_first(*find_args, *runtime_args), &runtime_block
         end
       end
     end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -7,8 +7,8 @@ module SitePrism
     attr_reader :root_element, :parent
 
     def initialize(parent, root_element)
-      @parent = parent
-      @root_element = root_element
+      @parent, @root_element = parent, root_element
+      Capybara.within(@root_element) { yield(self) } if block_given?
     end
 
     def visible?
@@ -31,12 +31,6 @@ module SitePrism
       candidate_page
     end
 
-    def within &block
-      Capybara.within(@root_element) do
-        block.call(self)
-      end
-    end
-
     private
 
     def find_first(*find_args)
@@ -54,6 +48,5 @@ module SitePrism
     def element_does_not_exist?(*find_args)
       root_element.has_no_selector?(*find_args) unless root_element.nil?
     end
-
   end
 end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -31,6 +31,12 @@ module SitePrism
       candidate_page
     end
 
+    def within &block
+      Capybara.within(@root_element) do
+        block.call(self)
+      end
+    end
+
     private
 
     def find_first(*find_args)
@@ -48,5 +54,6 @@ module SitePrism
     def element_does_not_exist?(*find_args)
       root_element.has_no_selector?(*find_args) unless root_element.nil?
     end
+
   end
 end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -7,7 +7,8 @@ module SitePrism
     attr_reader :root_element, :parent
 
     def initialize(parent, root_element)
-      @parent, @root_element = parent, root_element
+      @parent = parent
+      @root_element = root_element
       Capybara.within(@root_element) { yield(self) } if block_given?
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -266,7 +266,7 @@ describe SitePrism::Page do
     expect(SitePrism::Page.new).to respond_to :title
   end
 
-  it 'should raise exception if passing a block to an element' do
+  it 'should raise an exception if passing a block to an element' do
     expect do
       TestHomePage.new.invisible_element do
         puts 'bla'
@@ -274,7 +274,7 @@ describe SitePrism::Page do
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it 'should raise exception if passing a block to elements' do
+  it 'should raise an exception if passing a block to elements' do
     expect do
       TestHomePage.new.lots_of_links do
         puts 'bla'
@@ -282,7 +282,7 @@ describe SitePrism::Page do
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it 'should raise exception if passing a block to sections' do
+  it 'should raise an exception if passing a block to sections' do
     expect do
       TestHomePage.new.nonexistent_section do
         puts 'bla'

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -282,14 +282,6 @@ describe SitePrism::Page do
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it 'should raise exception if passing a block to a section' do
-    expect do
-      TestHomePage.new.people do
-        puts 'bla'
-      end
-    end.to raise_error(SitePrism::UnsupportedBlock)
-  end
-
   it 'should raise exception if passing a block to sections' do
     expect do
       TestHomePage.new.nonexistent_section do

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -51,6 +51,7 @@ describe SitePrism::Page do
       it 'should raise an ArgumentError' do
         class Page < SitePrism::Page
         end
+      
         expect { Page.section :incorrect_section, '.section' }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
       end
     end
@@ -66,13 +67,12 @@ describe SitePrism::Section do
     expect(SitePrism::Section).to respond_to :elements
   end
 
-  it 'should respond to javascript methods' do
-    class JsSection < SitePrism::Section
+  describe 'instance' do
+    subject(:section) { SitePrism::Section.new('parent', 'locator') }
+
+    it "should respond to javascript methods" do
+      expect(section).to respond_to :execute_script
+      expect(section).to respond_to :evaluate_script
     end
-
-    page = PageWithSection.new
-
-    expect(JsSection.new(page, 'a')).to respond_to :execute_script
-    expect(JsSection.new(page, 'a')).to respond_to :evaluate_script
   end
 end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -59,7 +59,9 @@ describe SitePrism::Page do
 end
 
 describe SitePrism::Section do
-  it 'should respond to element' do
+  let(:a_page) { class Page < SitePrism::Page; end }
+
+  it "should respond to element" do
     expect(SitePrism::Section).to respond_to :element
   end
 
@@ -67,10 +69,20 @@ describe SitePrism::Section do
     expect(SitePrism::Section).to respond_to :elements
   end
 
+  it 'passes a given block to Capybara.within' do
+    expect(Capybara).to receive(:within).with('div')
+    SitePrism::Section.new(a_page, 'div') { 1+1 }
+  end
+
+  it 'does not require a block' do
+    expect(Capybara).to_not receive(:within)
+    SitePrism::Section.new(a_page, 'div')
+  end
+
   describe 'instance' do
     subject(:section) { SitePrism::Section.new('parent', 'locator') }
 
-    it "should respond to javascript methods" do
+    it "responds to javascript methods" do
       expect(section).to respond_to :execute_script
       expect(section).to respond_to :evaluate_script
     end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -51,7 +51,6 @@ describe SitePrism::Page do
       it 'should raise an ArgumentError' do
         class Page < SitePrism::Page
         end
-      
         expect { Page.section :incorrect_section, '.section' }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
       end
     end
@@ -61,17 +60,17 @@ end
 describe SitePrism::Section do
   let(:a_page) { class Page < SitePrism::Page; end }
 
-  it "should respond to element" do
+  it 'responds to element' do
     expect(SitePrism::Section).to respond_to :element
   end
 
-  it 'should respond to elements' do
+  it 'responds to elements' do
     expect(SitePrism::Section).to respond_to :elements
   end
 
   it 'passes a given block to Capybara.within' do
     expect(Capybara).to receive(:within).with('div')
-    SitePrism::Section.new(a_page, 'div') { 1+1 }
+    SitePrism::Section.new(a_page, 'div') { 1 + 1 }
   end
 
   it 'does not require a block' do
@@ -82,7 +81,7 @@ describe SitePrism::Section do
   describe 'instance' do
     subject(:section) { SitePrism::Section.new('parent', 'locator') }
 
-    it "responds to javascript methods" do
+    it 'responds to javascript methods' do
       expect(section).to respond_to :execute_script
       expect(section).to respond_to :evaluate_script
     end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -45,13 +45,13 @@
       </table>
     </p>
 
-		<article class='people'>
-			<h1>People</h1>
-			<span class='person'>person 1</span>
-			<span class='person'>person 2</span>
-			<span class='person'>person 3</span>
-			<span class='person'>person 4</span>
-		</article>
+    <article class='people'>
+      <h1>People</h1>
+      <span class='person'>person 1</span>
+      <span class='person'>person 2</span>
+      <span class='person'>person 3</span>
+      <span class='person'>person 4</span>
+    </article>
 
     <input type='submit' id='remove_container_with_element' onClick='removeElement(document.getElementById("container_with_element"))'/>
 

--- a/test_site/sections/people.rb
+++ b/test_site/sections/people.rb
@@ -3,4 +3,6 @@ class People < SitePrism::Section
   element :dinosaur, '.dinosaur' # doesn't exist on the page
 
   elements :individuals, '.person'
+
+  element :welcome_message_on_the_parent, 'span.welcome' # should not be found here
 end


### PR DESCRIPTION
This makes for shorter test code when working within nested sections.
 - similar to Capybara's within

Compare:
```ruby
@page.top_section.child_section.should have_element1
@page.top_section.child_section.should have_element2
@page.top_section.child_section.should have_element3
````

```ruby
@page.top_section.child_section.within do |child|
  child.should have_element1
  child.should have_element2
  child.should have_element3
end
````