### PR TITLE
Add possibility to load an arbitrary page

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ navigate to the URL set against that page's class.
 
 See https://github.com/sporkmonger/addressable for more details on parameterized URLs.
 
+### Navigating to an arbitrary url
+
+The `#load_url` method might be useful when the page under test can be accessed by different urls
+(e.g. new and edit pages using the same form for a given resource).
+
+```
+class PageWithNoUrl < SitePrism::Page
+  # Note that you don't need set_url in this case
+end
+
+@page = PageWithNoUrl.new
+@page.load_url edit_user_path(user_id)
+```
+
 ### Verifying that a particular page is displayed
 
 Automated tests often need to verify that a particular page is

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -18,6 +18,10 @@ module SitePrism
       end
     end
 
+    def load_url(url)
+      visit url
+    end
+
     def displayed?(seconds = Waiter.default_wait_time)
       raise SitePrism::NoUrlMatcherForPage if url_matcher.nil?
       begin

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -24,6 +24,14 @@ describe SitePrism::Page do
     expect(page.url).to be_nil
   end
 
+  it "should allow navigation to arbitrary url" do
+    PageWithoutUrl = Class.new(SitePrism::Page)
+    page = PageWithoutUrl.new
+    path = '/foo/12/edit'
+    expect(page).to receive(:visit).with(path)
+    page.load_url path
+  end
+
   it "should not allow loading if the url hasn't been set" do
     class MyPageWithNoUrl < SitePrism::Page; end
     page_with_no_url = MyPageWithNoUrl.new


### PR DESCRIPTION
The `#load_url` method might be useful when the page under test can be
accessed by different urls (e.g. new and edit pages using the same form
for a given resource).

And, yes, this could be achieved with current parametrized load method, but it does not look so good on the tests.
