### PR TITLE
Add examples using label text to fined elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,30 @@ Here we're adding a search field to the Home page. The `element` method
 takes 2 arguments: the name of the element as a symbol, and a css selector
 as a string.
 
+#### Finding elements via text
+
+An element can be found via its name, id, text, label text, or value, depending
+on the type of element.
+
+```ruby
+class Login < SitePrism::Page
+  element :email, :field, "Email Address"
+  element :login_button, :button, "Login"
+  element :forgot_password_link, :link, "Forgot your password?"
+end
+```
+
+Elements will match against a substring of text, unless the `exact: true`
+option is passed. For example, the following two will find `"First Name"`, but
+only the first element will find `"My First Pet"`.
+
+```ruby
+class Example < SitePrism::Page
+  element :first_name, :field, "First"
+  element :first_name_exact, :field, "First Name", exact: true
+end
+```
+
 #### Accessing the individual element
 
 The `element` method will add a number of methods to instances of the

--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -26,6 +26,14 @@ Feature: Page element interaction
     But I cannot see the missing squirrel
     And I cannot see the missing other thingy
 
+  Scenario: Get elements using their text
+    When I navigate to the home page
+    Then I can find an input nested inside a label
+    And I can find an input using a label's for attribute
+    And I can find a button using its text
+    And I can find a link using its text
+
+
   Scenario: Get individual elements with query options
     When I navigate to the home page
     Then the welcome header is not matched with invalid text

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -68,7 +68,7 @@ Then(/^I can see the group of links$/) do
 end
 
 Then(/^I can get the group of links$/) do
-  expect(@test_site.home.lots_of_links.map { |link| link.text }).to eq(%w(a b c))
+  expect(@test_site.home.lots_of_links.map(&:text)).to eq(%w(a b c))
 end
 
 Then(/^all expected elements are present$/) do

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -146,7 +146,6 @@ Then(/^I can wait a variable time and pass specific parameters$/) do
   end
 end
 
-
 Then(/^I can find an input nested inside a label$/) do
   expect(@test_site.home).to have_nested_input
 end

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -145,3 +145,20 @@ Then(/^I can wait a variable time and pass specific parameters$/) do
     expect(@test_site.home.wait_for_lots_of_links(nil, count: 198_108_14)).to be false
   end
 end
+
+
+Then(/^I can find an input nested inside a label$/) do
+  expect(@test_site.home).to have_nested_input
+end
+
+Then(/^I can find an input using a label's for attribute$/) do
+  expect(@test_site.home).to have_label_for_input
+end
+
+Then(/^I can find a button using its text$/) do
+  expect(@test_site.home).to have_submit_button
+end
+
+Then(/^I can find a link using its text$/) do
+  expect(@test_site.home).to have_search_link
+end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -67,6 +67,17 @@
     <input type='submit' id='will_become_invisible' value='Will become invisible' style='display: block;'/>
     <input type='submit' class='invisible' value='Invisible' style='display: none;'/>
 
+    <form>
+      <label>
+        With a field inside
+        <input type='text' value='a textbox' />
+      </label>
+      <label for='another_textbox'>Using for attribute</label>
+      <input type='text' id='another_textbox' value='another textbox'/>
+      <input type='submit' value='submit it'/>
+    </form>
+
     <iframe id='the_iframe' src='my_iframe.htm' />
+
   </body>
 </html>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -31,4 +31,11 @@ class TestHomePage < SitePrism::Page
   # iframes
   iframe :my_iframe, MyIframe, '#the_iframe'
   iframe :index_iframe, MyIframe, 0
+
+  # elements via text
+  element :nested_input, :field, 'With a field inside'
+  element :label_for_input, :field, 'Using for attribute'
+  element :submit_button, :button, 'submit it'
+  element :search_link, :link, 'Search Page'
+
 end

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -37,5 +37,4 @@ class TestHomePage < SitePrism::Page
   element :label_for_input, :field, 'Using for attribute'
   element :submit_button, :button, 'submit it'
   element :search_link, :link, 'Search Page'
-
 end


### PR DESCRIPTION
We found it really useful to use form labels as the selector for finding inputs. There were no examples of this in the Readme, but it works since the parameters are delegated down to Capybara. 

I would consider submitting a PR to add those helpers to `SitePrism::Page` if there is a chance it would be accepted. I'm not sure if that additional API is desired.