### PR TITLE
Expose url matches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'selenium-webdriver'
 group :development do
   gem 'yard'
   gem 'redcarpet'
-  gem 'simplecov'
+  gem 'simplecov', require: false
   gem 'reek'
   gem 'rubocop'
 end

--- a/README.md
+++ b/README.md
@@ -260,6 +260,43 @@ expect(@account_page).to be_displayed
 Calling `#displayed?` will return true if the browser's current URL
 matches the page's template and false if it doesn't.
 
+#### Specifying parameter values for templated URLs
+
+Sometimes you want to verify not just that the current URL matches the
+template, but that you're looking at a specific page matching that
+template.
+
+Given the previous example, if you wanted to ensure that the browser had loaded
+account number 22, you could assert the following:
+
+```ruby
+expect(@account_page).to be_displayed(id: 22)
+```
+
+You can even use regular expressions.  If, as a contrived example, you wanted to
+ensure that the browser was displaying an account with an id ending with 2, you could
+say:
+
+```ruby
+expect(@account_page).to be_displayed(id: /2\z/)
+```
+
+#### Accessing specific matches from a templated URL in your tests
+
+If passing options to `displayed?` isn't powerful enough to meet your
+needs, you can directly access and assert on the `url_matches` found
+when comparing your page's URL template to the current_url:
+
+```ruby
+@account_page = Account.new
+@account_page.load(id: 22, query: { token: "ca2786616a4285bc", color: 'irrelevant' })
+
+expect(@account_page).to be_displayed(id: 22)
+expect(@account_page.url_matches['query']['token']).to eq "ca2786616a4285bc"
+```
+
+#### Falling back to basic regexp matchers
+
 If SitePrism's built-in URL matching is not sufficient for your needs
  you can override and use SitePrism's previous support for regular expression-based
 URL matchers by it by calling `set_url_matcher`:
@@ -281,23 +318,6 @@ Then /^the account page is displayed$/ do
   expect(@some_other_page).not_to be_displayed
 end
 ```
-
-Another example that demonstrates why using regex instead of string
-comparison for URL checking is when you want to be able to run your
-tests across multiple environments.
-
-```ruby
-class Login < SitePrism::Page
-  set_url "#{$test_environment}.example.com/login" #=> global var used for demonstration purposes only!!!
-  set_url_matcher /(?:dev|test|www)\.example\.com\/login/
-end
-```
-
-The above example would work for `dev.example.com/login`,
-`test.example.com/login` and `www.example.com/login`; now your tests
-aren't limited to one environment but can verify that they are on the
-correct page regardless of the environment the tests are being executed
-against.
 
 ### Getting the Current Page's URL
 

--- a/lib/site_prism/addressable_url_matcher.rb
+++ b/lib/site_prism/addressable_url_matcher.rb
@@ -15,12 +15,45 @@ module SitePrism
       @pattern = pattern
     end
 
-    def matches?(url)
+    # @return the hash of extracted mappings from parsing the provided URL according to our pattern,
+    # or nil if the URL doesn't conform to the matcher template.
+    def mappings(url)
       uri = Addressable::URI.parse(url)
-      COMPONENT_NAMES.all? { |component| component_matches?(component, uri) }
+      result = {}
+      COMPONENT_NAMES.each do |component|
+        component_result = component_matches(component, uri)
+        result = component_result ? result.merge!(component_result) : nil
+        break unless result
+      end
+      result
+    end
+
+    # Determine whether URL matches our pattern, and optionally whether the extracted mappings match
+    # a hash of expected values.  You can specify values as strings, numbers or regular expressions.
+    def matches?(url, expected_mappings = {})
+      actual_mappings = mappings(url)
+      if actual_mappings
+        expected_mappings.empty? ? true : all_expected_mappings_match?(expected_mappings, actual_mappings)
+      else
+        false
+      end
     end
 
     private
+
+    def all_expected_mappings_match?(expected_mappings, actual_mappings)
+      expected_mappings.all? do |key, expected_value|
+        actual_value = actual_mappings[key.to_s]
+        case expected_value
+        when Numeric
+          actual_value == expected_value.to_s
+        when Regexp
+          actual_value.match(expected_value)
+        else
+          expected_value == actual_value
+        end
+      end
+    end
 
     # Memoizes the extracted component templates
     def component_templates
@@ -41,18 +74,20 @@ module SitePrism
       end.freeze
     end
 
-    # Returns true if the template omits the component or the provided URI component matches the template component
-    def component_matches?(component, uri)
+    # Returns empty hash if the template omits the component, a set of substitutions if the
+    # provided URI component matches the template component, or nil if the match fails.
+    def component_matches(component, uri)
+      extracted_mappings = {}
       component_template = component_templates[component]
       if component_template
         component_url = uri.public_send(component).to_s
-        unless component_template.extract(component_url)
+        unless (extracted_mappings = component_template.extract(component_url))
           # to support Addressable's expansion of queries, ensure it's parsing the fragment as appropriate (e.g. {?params*})
           prefix = COMPONENT_PREFIXES[component]
-          return false unless prefix && component_template.extract(prefix + component_url)
+          return nil unless prefix && (extracted_mappings = component_template.extract(prefix + component_url))
         end
       end
-      true
+      extracted_mappings
     end
 
     # Convert the pattern into an Addressable URI by substituting the template slugs with nonsense strings.

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -18,10 +18,12 @@ module SitePrism
       end
     end
 
-    def displayed?(seconds = Waiter.default_wait_time)
+    def displayed?(*args)
+      expected_mappings = args.last.is_a?(::Hash) ? args.pop : {}
+      seconds = args.length > 0 ? args.first : Waiter.default_wait_time
       fail SitePrism::NoUrlMatcherForPage if url_matcher.nil?
       begin
-        Waiter.wait_until_true(seconds) { url_matches? }
+        Waiter.wait_until_true(seconds) { url_matches?(expected_mappings) }
       rescue SitePrism::TimeoutException
         false
       end
@@ -74,11 +76,11 @@ module SitePrism
       has_no_selector?(*find_args)
     end
 
-    def url_matches?
+    def url_matches?(expected_mappings = {})
       if url_matcher.is_a?(Regexp)
         url_matches_by_regexp?
       elsif url_matcher.respond_to?(:to_str)
-        url_matches_by_template?
+        url_matches_by_template?(expected_mappings)
       else
         fail SitePrism::InvalidUrlMatcher
       end
@@ -88,8 +90,8 @@ module SitePrism
       !(page.current_url =~ url_matcher).nil?
     end
 
-    def url_matches_by_template?
-      matcher_template.matches?(page.current_url)
+    def url_matches_by_template?(expected_mappings)
+      matcher_template.matches?(page.current_url, expected_mappings)
     end
 
     def matcher_template

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -34,10 +34,8 @@ module SitePrism
 
       if url_matcher.is_a?(Regexp)
         regexp_backed_matches
-      elsif url_matcher.respond_to?(:to_str)
-        template_backed_matches
       else
-        fail SitePrism::InvalidUrlMatcher
+        template_backed_matches
       end
     end
 

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -76,12 +76,20 @@ module SitePrism
 
     def url_matches?
       if url_matcher.is_a?(Regexp)
-        !(page.current_url =~ url_matcher).nil?
+        url_matches_by_regexp?
       elsif url_matcher.respond_to?(:to_str)
-        matcher_template.matches?(page.current_url)
+        url_matches_by_template?
       else
         fail SitePrism::InvalidUrlMatcher
       end
+    end
+
+    def url_matches_by_regexp?
+      !(page.current_url =~ url_matcher).nil?
+    end
+
+    def url_matches_by_template?
+      matcher_template.matches?(page.current_url)
     end
 
     def matcher_template

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -29,6 +29,26 @@ module SitePrism
       end
     end
 
+    def url_matches(seconds = Waiter.default_wait_time)
+      return unless displayed?(seconds)
+
+      if url_matcher.is_a?(Regexp)
+        regexp_backed_matches
+      elsif url_matcher.respond_to?(:to_str)
+        template_backed_matches
+      else
+        fail SitePrism::InvalidUrlMatcher
+      end
+    end
+
+    def regexp_backed_matches
+      url_matcher.match(page.current_url)
+    end
+
+    def template_backed_matches
+      matcher_template.mappings(page.current_url)
+    end
+
     def self.set_url(page_url)
       @url = page_url.to_s
     end
@@ -87,7 +107,7 @@ module SitePrism
     end
 
     def url_matches_by_regexp?
-      !(page.current_url =~ url_matcher).nil?
+      !regexp_backed_matches.nil?
     end
 
     def url_matches_by_template?(expected_mappings)

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -176,7 +176,7 @@ describe SitePrism::Page do
 
   context 'with a parameterized URL matcher' do
     class PageWithParameterizedUrlMatcher < SitePrism::Page
-      set_url_matcher '/foos{/id}'
+      set_url_matcher '{scheme}:///foos{/id}'
     end
 
     let(:page) { PageWithParameterizedUrlMatcher.new }
@@ -206,6 +206,43 @@ describe SitePrism::Page do
     it 'passes through correct expected_mappings from the be_displayed matcher' do
       swap_current_url('http://localhost:3000/foos/28')
       expect(page).to be_displayed id: 28
+    end
+
+    describe '#url_matches' do
+      it 'returns mappings from the current_url' do
+        swap_current_url('http://localhost:3000/foos/15')
+        expect(page.url_matches).to eq 'scheme' => 'http', 'id' => '15'
+      end
+
+      it "returns nil if current_url doesn't match the url_matcher" do
+        swap_current_url('http://localhost:3000/bars/15')
+        expect(page.url_matches).to eq nil
+      end
+    end
+  end
+
+  describe 'with a regexp matcher' do
+    class PageWithRegexpUrlMatcher < SitePrism::Page
+      set_url_matcher(/foos\/(\d+)/)
+    end
+
+    let(:page) { PageWithRegexpUrlMatcher.new }
+
+    describe '#url_matches' do
+      it 'returns regexp MatchData' do
+        swap_current_url('http://localhost:3000/foos/15')
+        expect(page.url_matches).to be_kind_of(MatchData)
+      end
+
+      it 'lets you get at the captures' do
+        swap_current_url('http://localhost:3000/foos/15')
+        expect(page.url_matches[1]).to eq '15'
+      end
+
+      it "returns nil if current_url doesn't match the url_matcher" do
+        swap_current_url('http://localhost:3000/bars/15')
+        expect(page.url_matches).to eq nil
+      end
     end
   end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -174,6 +174,41 @@ describe SitePrism::Page do
     end
   end
 
+  context 'with a parameterized URL matcher' do
+    class PageWithParameterizedUrlMatcher < SitePrism::Page
+      set_url_matcher '/foos{/id}'
+    end
+
+    let(:page) { PageWithParameterizedUrlMatcher.new }
+
+    describe '#displayed?' do
+      it 'returns true without expected_mappings provided' do
+        swap_current_url('http://localhost:3000/foos/28')
+        expect(page.displayed?).to eq(true)
+      end
+
+      it 'returns true with correct expected_mappings provided' do
+        swap_current_url('http://localhost:3000/foos/28')
+        expect(page.displayed?(id: 28)).to eq(true)
+      end
+
+      it 'returns false with incorrect expected_mappings provided' do
+        swap_current_url('http://localhost:3000/foos/28')
+        expect(page.displayed?(id: 17)).to eq(false)
+      end
+    end
+
+    it 'passes through incorrect expected_mappings from the be_displayed matcher' do
+      swap_current_url('http://localhost:3000/foos/28')
+      expect(page).not_to be_displayed id: 17
+    end
+
+    it 'passes through correct expected_mappings from the be_displayed matcher' do
+      swap_current_url('http://localhost:3000/foos/28')
+      expect(page).to be_displayed
+    end
+  end
+
   it 'should expose the page title' do
     expect(SitePrism::Page.new).to respond_to :title
   end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -91,6 +91,22 @@ describe SitePrism::Page do
     expect { page.displayed? }.to_not raise_error
   end
 
+  describe 'with a bogus URL matcher' do
+    class PageWithBogusFullUrlMatcher < SitePrism::Page
+      set_url_matcher this: "isn't a URL matcher"
+    end
+
+    let(:page) { PageWithBogusFullUrlMatcher.new }
+
+    specify '#url_matches raises InvalidUrlMatcher' do
+      expect { page.url_matches }.to raise_error SitePrism::InvalidUrlMatcher
+    end
+
+    specify '#displayed? raises InvalidUrlMatcher' do
+      expect { page.displayed? }.to raise_error SitePrism::InvalidUrlMatcher
+    end
+  end
+
   describe 'with a full string URL matcher' do
     class PageWithStringFullUrlMatcher < SitePrism::Page
       set_url_matcher 'https://joe:bump@bla.org:443/foo?bar=baz&bar=boof#myfragment'

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -205,7 +205,7 @@ describe SitePrism::Page do
 
     it 'passes through correct expected_mappings from the be_displayed matcher' do
       swap_current_url('http://localhost:3000/foos/28')
-      expect(page).to be_displayed
+      expect(page).to be_displayed id: 28
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+unless ENV['CI']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require 'capybara'
 require 'capybara/dsl'
 require 'selenium-webdriver'


### PR DESCRIPTION
Hi @natritmeyer, as threatened, here's a follow-on PR that allows siteprism users to easily verify templated URL values via a parameterized `#displayed?` method for simple use cases and `#url_matches` for more complex tests.  The README update describes the features in pretty good detail, and the tests should be revealing.

We've gotten good mileage out of it at Betterment when we want to validate that a certain object ID or query string parameter is in place, and it keeps our SitePrism code 100% regexp-free.  Again no backwards compatibility loss, and in the name of not violating POLA, `#url_matches` does something sensible even if you use Regexp-style matchers - it returns the `MatchData` object.