### PR TITLE
Not allowing blocks in element(s) and section(s)

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -3,6 +3,7 @@ module SitePrism::ElementContainer
   def element(element_name, *find_args)
     build element_name, *find_args do
       define_method element_name.to_s do |*runtime_args|
+        raise_if_block(element_name, block_given?)
         find_first *find_args, *runtime_args
       end
     end
@@ -11,6 +12,7 @@ module SitePrism::ElementContainer
   def elements(collection_name, *find_args)
     build collection_name, *find_args do
       define_method collection_name.to_s do |*runtime_args|
+        raise_if_block(collection_name, block_given?)
         find_all *find_args, *runtime_args
       end
     end
@@ -21,6 +23,7 @@ module SitePrism::ElementContainer
     section_class, find_args = extract_section_options args, &block
     build section_name, *find_args do
       define_method section_name do | *runtime_args |
+        raise_if_block(section_name, block_given?)
         section_class.new self, find_first(*find_args, *runtime_args)
       end
     end
@@ -30,6 +33,7 @@ module SitePrism::ElementContainer
     section_class, find_args = extract_section_options args, &block
     build section_collection_name, *find_args do
       define_method section_collection_name do |*runtime_args|
+        raise_if_block(section_collection_name, block_given?)
         find_all(*find_args, *runtime_args).collect do |element|
           section_class.new self, element
         end
@@ -61,6 +65,10 @@ module SitePrism::ElementContainer
   end
 
   private
+  def raise_if_block(name, has_block)
+    return unless has_block
+    raise "#{name} does not accept blocks, did you mean to define a (i)frame?"
+  end
 
   def build(name, *find_args)
     if find_args.empty?

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -4,8 +4,8 @@ module SitePrism
 
     def element(element_name, *find_args)
       build element_name, *find_args do
-        define_method element_name.to_s do |*runtime_args, &block|
-          self.class.raise_if_block(self, element_name.to_s, !block.nil?)
+        define_method element_name.to_s do |*runtime_args, &element_block|
+          self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
           find_first(*find_args, *runtime_args)
         end
       end
@@ -13,8 +13,8 @@ module SitePrism
 
     def elements(collection_name, *find_args)
       build collection_name, *find_args do
-        define_method collection_name.to_s do |*runtime_args, &block|
-          self.class.raise_if_block(self, collection_name.to_s, !block.nil?)
+        define_method collection_name.to_s do |*runtime_args, &element_block|
+          self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
           find_all(*find_args, *runtime_args)
         end
       end
@@ -24,8 +24,8 @@ module SitePrism
     def section(section_name, *args, &block)
       section_class, find_args = extract_section_options args, &block
       build section_name, *find_args do
-        define_method section_name do | *runtime_args, &block |
-          self.class.raise_if_block(self, section_name.to_s, !block.nil?)
+        define_method section_name do | *runtime_args, &element_block |
+          self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
           section_class.new self, find_first(*find_args, *runtime_args)
         end
       end
@@ -34,8 +34,8 @@ module SitePrism
     def sections(section_collection_name, *args, &block)
       section_class, find_args = extract_section_options args, &block
       build section_collection_name, *find_args do
-        define_method section_collection_name do |*runtime_args, &block|
-          self.class.raise_if_block(self, section_collection_name.to_s, !block.nil?)
+        define_method section_collection_name do |*runtime_args, &element_block|
+          self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
           find_all(*find_args, *runtime_args).map do |element|
             section_class.new self, element
           end
@@ -64,7 +64,7 @@ module SitePrism
 
     def raise_if_block(obj, name, has_block)
       return unless has_block
-      raise SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
+      fail SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
     end
 
     private

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -6,4 +6,5 @@ module SitePrism
   class TimeoutException < StandardError; end
   class TimeOutWaitingForElementVisibility < StandardError; end
   class TimeOutWaitingForElementInvisibility < StandardError; end
+  class UnsupportedBlock < StandardError;  end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -22,16 +22,14 @@ describe SitePrism::Page do
   end
 
   it 'url should be nil by default' do
-    class PageDefaultUrl < SitePrism::Page;
-    end
+    class PageDefaultUrl < SitePrism::Page; end
     page = PageDefaultUrl.new
     expect(PageDefaultUrl.url).to be_nil
     expect(page.url).to be_nil
   end
 
   it "should not allow loading if the url hasn't been set" do
-    class MyPageWithNoUrl < SitePrism::Page;
-    end
+    class MyPageWithNoUrl < SitePrism::Page; end
     page_with_no_url = MyPageWithNoUrl.new
     expect { page_with_no_url.load }.to raise_error
   end
@@ -50,14 +48,13 @@ describe SitePrism::Page do
     end
     page_with_url = MyPageWithUriTemplate.new
     expect { page_with_url.load(username: 'foobar') }.to_not raise_error
-    expect(page_with_url.url(username: 'foobar', query: {'recent_posts' => 'true'})).to eq('/users/foobar?recent_posts=true')
+    expect(page_with_url.url(username: 'foobar', query: { 'recent_posts' => 'true' })).to eq('/users/foobar?recent_posts=true')
     expect(page_with_url.url(username: 'foobar')).to eq('/users/foobar')
     expect(page_with_url.url).to eq('/users')
   end
 
   it 'should allow to load html' do
-    class Page < SitePrism::Page;
-    end
+    class Page < SitePrism::Page; end
     page = Page.new
     expect { page.load('<html/>') }.to_not raise_error
   end
@@ -67,8 +64,7 @@ describe SitePrism::Page do
   end
 
   it 'url matcher should be nil by default' do
-    class PageDefaultUrlMatcher < SitePrism::Page;
-    end
+    class PageDefaultUrlMatcher < SitePrism::Page; end
     page = PageDefaultUrlMatcher.new
     expect(PageDefaultUrlMatcher.url_matcher).to be_nil
     expect(page.url_matcher).to be_nil
@@ -83,8 +79,7 @@ describe SitePrism::Page do
   end
 
   it 'should raise an exception if displayed? is called before the matcher has been set' do
-    class PageWithNoMatcher < SitePrism::Page;
-    end
+    class PageWithNoMatcher < SitePrism::Page; end
     expect { PageWithNoMatcher.new.displayed? }.to raise_error SitePrism::NoUrlMatcherForPage
   end
 
@@ -183,34 +178,34 @@ describe SitePrism::Page do
     expect(SitePrism::Page.new).to respond_to :title
   end
 
-  it "should raise exception if passing a block to an element" do
+  it 'should raise exception if passing a block to an element' do
     expect do
       TestHomePage.new.invisible_element do
-        puts "bla"
+        puts 'bla'
       end
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it "should raise exception if passing a block to elements" do
+  it 'should raise exception if passing a block to elements' do
     expect do
       TestHomePage.new.lots_of_links do
-        puts "bla"
+        puts 'bla'
       end
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it "should raise exception if passing a block to a section" do
+  it 'should raise exception if passing a block to a section' do
     expect do
       TestHomePage.new.people do
-        puts "bla"
+        puts 'bla'
       end
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
-  it "should raise exception if passing a block to sections" do
+  it 'should raise exception if passing a block to sections' do
     expect do
       TestHomePage.new.nonexistent_section do
-        puts "bla"
+        puts 'bla'
       end
     end.to raise_error(SitePrism::UnsupportedBlock)
   end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -22,14 +22,16 @@ describe SitePrism::Page do
   end
 
   it 'url should be nil by default' do
-    class PageDefaultUrl < SitePrism::Page; end
+    class PageDefaultUrl < SitePrism::Page;
+    end
     page = PageDefaultUrl.new
     expect(PageDefaultUrl.url).to be_nil
     expect(page.url).to be_nil
   end
 
   it "should not allow loading if the url hasn't been set" do
-    class MyPageWithNoUrl < SitePrism::Page; end
+    class MyPageWithNoUrl < SitePrism::Page;
+    end
     page_with_no_url = MyPageWithNoUrl.new
     expect { page_with_no_url.load }.to raise_error
   end
@@ -48,13 +50,14 @@ describe SitePrism::Page do
     end
     page_with_url = MyPageWithUriTemplate.new
     expect { page_with_url.load(username: 'foobar') }.to_not raise_error
-    expect(page_with_url.url(username: 'foobar', query: { 'recent_posts' => 'true' })).to eq('/users/foobar?recent_posts=true')
+    expect(page_with_url.url(username: 'foobar', query: {'recent_posts' => 'true'})).to eq('/users/foobar?recent_posts=true')
     expect(page_with_url.url(username: 'foobar')).to eq('/users/foobar')
     expect(page_with_url.url).to eq('/users')
   end
 
   it 'should allow to load html' do
-    class Page < SitePrism::Page; end
+    class Page < SitePrism::Page;
+    end
     page = Page.new
     expect { page.load('<html/>') }.to_not raise_error
   end
@@ -64,7 +67,8 @@ describe SitePrism::Page do
   end
 
   it 'url matcher should be nil by default' do
-    class PageDefaultUrlMatcher < SitePrism::Page; end
+    class PageDefaultUrlMatcher < SitePrism::Page;
+    end
     page = PageDefaultUrlMatcher.new
     expect(PageDefaultUrlMatcher.url_matcher).to be_nil
     expect(page.url_matcher).to be_nil
@@ -79,7 +83,8 @@ describe SitePrism::Page do
   end
 
   it 'should raise an exception if displayed? is called before the matcher has been set' do
-    class PageWithNoMatcher < SitePrism::Page; end
+    class PageWithNoMatcher < SitePrism::Page;
+    end
     expect { PageWithNoMatcher.new.displayed? }.to raise_error SitePrism::NoUrlMatcherForPage
   end
 
@@ -179,19 +184,35 @@ describe SitePrism::Page do
   end
 
   it "should raise exception if passing a block to an element" do
-    expect{TestHomePage.new.invisible_element {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+    expect do
+      TestHomePage.new.invisible_element do
+        puts "bla"
+      end
+    end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   it "should raise exception if passing a block to elements" do
-    expect{TestHomePage.new.lots_of_links {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+    expect do
+      TestHomePage.new.lots_of_links do
+        puts "bla"
+      end
+    end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   it "should raise exception if passing a block to a section" do
-    expect{TestHomePage.new.people {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+    expect do
+      TestHomePage.new.people do
+        puts "bla"
+      end
+    end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   it "should raise exception if passing a block to sections" do
-    expect{TestHomePage.new.nonexistent_section {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+    expect do
+      TestHomePage.new.nonexistent_section do
+        puts "bla"
+      end
+    end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   def swap_current_url(url)

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -90,5 +90,21 @@ describe SitePrism::Page do
   it "should expose the page title" do
     expect(SitePrism::Page.new).to respond_to :title
   end
+
+  it "should raise exception if passing a block to an element" do
+    expect{TestHomePage.new.invisible_element {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+  end
+
+  it "should raise exception if passing a block to elements" do
+    expect{TestHomePage.new.lots_of_links {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+  end
+
+  it "should raise exception if passing a block to a section" do
+    expect{TestHomePage.new.people {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+  end
+
+  it "should raise exception if passing a block to sections" do
+    expect{TestHomePage.new.nonexistent_section {puts "bla"}}.to raise_error(SitePrism::ElementContainer::UnsupportedBlock)
+  end
 end
 


### PR DESCRIPTION
Currently users can pass blocks into element(s) and section(s) after refactoring iframe into a section or element. This causes false positives in tests as the actual code block is not being run.