### PR TITLE
Update the system to more carefully combine arguments.

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -6,7 +6,7 @@ module SitePrism
       build element_name, *find_args do
         define_method element_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-          find_first(*combine_args(find_args, runtime_args))
+          find_first(*self.class.send(:combine_args, find_args, runtime_args))
         end
       end
     end
@@ -15,7 +15,7 @@ module SitePrism
       build collection_name, *find_args do
         define_method collection_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-          find_all(*combine_args(find_args, runtime_args))
+          find_all(*self.class.send(:combine_args, find_args, runtime_args))
         end
       end
     end
@@ -26,7 +26,7 @@ module SitePrism
       build section_name, *find_args do
         define_method section_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
-          section_class.new self, find_first(*combine_args(find_args, runtime_args))
+          section_class.new self, find_first(*self.class.send(:combine_args, find_args, runtime_args))
         end
       end
     end
@@ -36,7 +36,7 @@ module SitePrism
       build section_collection_name, *find_args do
         define_method section_collection_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
-          find_all(*combine_args(find_args, runtime_args)).map do |element|
+          find_all(*self.class.send(:combine_args, find_args, runtime_args)).map do |element|
             section_class.new self, element
           end
         end
@@ -112,7 +112,7 @@ module SitePrism
         define_method method_name do |*runtime_args|
           wait_time = SitePrism.use_implicit_waits ? Capybara.default_wait_time : 0
           Capybara.using_wait_time wait_time do
-            element_exists?(*combine_args(find_args, runtime_args))
+            element_exists?(*self.class.send(:combine_args, find_args, runtime_args))
           end
         end
       end
@@ -124,7 +124,7 @@ module SitePrism
         define_method method_name do |*runtime_args|
           wait_time = SitePrism.use_implicit_waits ? Capybara.default_wait_time : 0
           Capybara.using_wait_time wait_time do
-            element_does_not_exist?(*combine_args(find_args, runtime_args))
+            element_does_not_exist?(*self.class.send(:combine_args, find_args, runtime_args))
           end
         end
       end
@@ -136,7 +136,7 @@ module SitePrism
         define_method method_name do |timeout = nil, *runtime_args|
           timeout = timeout.nil? ? Capybara.default_wait_time : timeout
           Capybara.using_wait_time timeout do
-            element_exists?(*combine_args(find_args, runtime_args))
+            element_exists?(*self.class.send(:combine_args, find_args, runtime_args))
           end
         end
       end
@@ -148,7 +148,7 @@ module SitePrism
         define_method method_name do |timeout = Capybara.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
             Capybara.using_wait_time 0 do
-              sleep 0.05 until element_exists?(*combine_args(find_args, runtime_args), visible: true)
+              sleep 0.05 until element_exists?(*self.class.send(:combine_args, find_args, runtime_args), visible: true)
             end
           end
         end
@@ -161,7 +161,7 @@ module SitePrism
         define_method method_name do |timeout = Capybara.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
             Capybara.using_wait_time 0 do
-              sleep 0.05 while element_exists?(*combine_args(find_args, runtime_args), visible: true)
+              sleep 0.05 while element_exists?(*self.class.send(:combine_args, find_args, runtime_args), visible: true)
             end
           end
         end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -6,7 +6,7 @@ module SitePrism
       build element_name, *find_args do
         define_method element_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-          find_first(*find_args, *runtime_args)
+          find_first(*combine_args(find_args, runtime_args))
         end
       end
     end
@@ -15,7 +15,7 @@ module SitePrism
       build collection_name, *find_args do
         define_method collection_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args)
+          find_all(*combine_args(find_args, runtime_args))
         end
       end
     end
@@ -26,7 +26,7 @@ module SitePrism
       build section_name, *find_args do
         define_method section_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
-          section_class.new self, find_first(*find_args, *runtime_args)
+          section_class.new self, find_first(*combine_args(find_args, runtime_args))
         end
       end
     end
@@ -36,7 +36,7 @@ module SitePrism
       build section_collection_name, *find_args do
         define_method section_collection_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args).map do |element|
+          find_all(*combine_args(find_args, runtime_args)).map do |element|
             section_class.new self, element
           end
         end
@@ -68,6 +68,18 @@ module SitePrism
     end
 
     private
+
+    def combine_args(arg_array1, arg_array2)
+      args = []
+      args += arg_array1
+      options1 = (args.pop if args[-1].is_a?(Hash)) || {}
+      args += arg_array2
+      options2 = (args.pop if args[-1].is_a?(Hash)) || {}
+
+      args << options1.merge(options2)
+
+      args
+    end
 
     def build(name, *find_args)
       if find_args.empty?
@@ -101,7 +113,7 @@ module SitePrism
         define_method method_name do |*runtime_args|
           wait_time = SitePrism.use_implicit_waits ? Capybara.default_wait_time : 0
           Capybara.using_wait_time wait_time do
-            element_exists?(*find_args, *runtime_args)
+            element_exists?(*combine_args(find_args, runtime_args))
           end
         end
       end
@@ -113,7 +125,7 @@ module SitePrism
         define_method method_name do |*runtime_args|
           wait_time = SitePrism.use_implicit_waits ? Capybara.default_wait_time : 0
           Capybara.using_wait_time wait_time do
-            element_does_not_exist?(*find_args, *runtime_args)
+            element_does_not_exist?(*combine_args(find_args, runtime_args))
           end
         end
       end
@@ -125,7 +137,7 @@ module SitePrism
         define_method method_name do |timeout = nil, *runtime_args|
           timeout = timeout.nil? ? Capybara.default_wait_time : timeout
           Capybara.using_wait_time timeout do
-            element_exists?(*find_args, *runtime_args)
+            element_exists?(*combine_args(find_args, runtime_args))
           end
         end
       end
@@ -137,7 +149,7 @@ module SitePrism
         define_method method_name do |timeout = Capybara.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
             Capybara.using_wait_time 0 do
-              sleep 0.05 until element_exists?(*find_args, *runtime_args, visible: true)
+              sleep 0.05 until element_exists?(*combine_args(find_args, runtime_args), visible: true)
             end
           end
         end
@@ -150,7 +162,7 @@ module SitePrism
         define_method method_name do |timeout = Capybara.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
             Capybara.using_wait_time 0 do
-              sleep 0.05 while element_exists?(*find_args, *runtime_args, visible: true)
+              sleep 0.05 while element_exists?(*combine_args(find_args, runtime_args), visible: true)
             end
           end
         end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -70,8 +70,7 @@ module SitePrism
     private
 
     def combine_args(arg_array1, arg_array2)
-      args = []
-      args += arg_array1
+      args = arg_array1.dup
       options1 = (args.pop if args[-1].is_a?(Hash)) || {}
       args += arg_array2
       options2 = (args.pop if args[-1].is_a?(Hash)) || {}

--- a/lib/site_prism/version.rb
+++ b/lib/site_prism/version.rb
@@ -1,3 +1,3 @@
 module SitePrism
-  VERSION = '2.6'
+  VERSION = '2.6.1'
 end

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -1,62 +1,62 @@
-require "spec_helper"
+require 'spec_helper'
 
-RSpec.describe "#combine_args" do
+RSpec.describe '#combine_args' do
   class FakeContainerClass
     include SitePrism::ElementContainer
   end
 
   let(:subject) { FakeContainerClass.new }
-  let(:array_args1) { [:css, "#argument-1"] }
-  let(:array_args2) { [:css, "#argument-2"] }
+  let(:array_args1) { [:css, '#argument-1'] }
+  let(:array_args2) { [:css, '#argument-2'] }
   let(:options_args1) { [{ minimum: 8 }] }
   let(:options_args2) { [{ count: 12 }] }
-  let(:array_options_args1) { [:css, "#argument-with-options-1", { visible: false }] }
-  let(:array_options_args2) { [:css, "#argument-with-options-2", { timeout: 30 }] }
+  let(:array_options_args1) { [:css, '#argument-with-options-1', { visible: false }] }
+  let(:array_options_args2) { [:css, '#argument-with-options-2', { timeout: 30 }] }
 
-  it "combines 2 arrays" do
-    expect(subject.send(:combine_args, array_args1, array_args2)).to eq [:css, "#argument-1", :css, "#argument-2", {}]
+  it 'combines 2 arrays' do
+    expect(subject.send(:combine_args, array_args1, array_args2)).to eq [:css, '#argument-1', :css, '#argument-2', {}]
   end
 
-  it "combines 2 arrays even if one is empty" do
-    expect(subject.send(:combine_args, array_args1, [])).to eq [:css, "#argument-1", {}]
+  it 'combines 2 arrays even if one is empty' do
+    expect(subject.send(:combine_args, array_args1, [])).to eq [:css, '#argument-1', {}]
   end
 
-  it "combines an array and options" do
-    expect(subject.send(:combine_args, array_args1, options_args2)).to eq [:css, "#argument-1", { count: 12 }]
+  it 'combines an array and options' do
+    expect(subject.send(:combine_args, array_args1, options_args2)).to eq [:css, '#argument-1', { count: 12 }]
   end
 
-  it "combines an array and an array with options" do
-    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [:css, "#argument-1", :css, "#argument-with-options-2", { timeout: 30 }]
+  it 'combines an array and an array with options' do
+    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [:css, '#argument-1', :css, '#argument-with-options-2', { timeout: 30 }]
   end
 
-  it "combines an array with options and an array" do
-    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-2", { visible: false }]
+  it 'combines an array with options and an array' do
+    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-2', { visible: false }]
   end
 
-  it "combines an array with options and options" do
-    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq [:css, "#argument-with-options-1", { visible: false, count: 12 }]
+  it 'combines an array with options and options' do
+    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq [:css, '#argument-with-options-1', { visible: false, count: 12 }]
   end
 
-  it "combines an array with options and an array with options" do
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-with-options-2", { visible: false, timeout: 30 }]
+  it 'combines an array with options and an array with options' do
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30 }]
   end
 
-  it "combines options and an array" do
-    expect(subject.send(:combine_args, options_args1, array_args2)).to eq [:css, "#argument-2", { minimum: 8 }]
+  it 'combines options and an array' do
+    expect(subject.send(:combine_args, options_args1, array_args2)).to eq [:css, '#argument-2', { minimum: 8 }]
   end
 
-  it "combines options and an array with options" do
-    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq [:css, "#argument-with-options-2", { minimum: 8, timeout: 30 }]
+  it 'combines options and an array with options' do
+    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq [:css, '#argument-with-options-2', { minimum: 8, timeout: 30 }]
   end
 
-  it "combines options and options" do
+  it 'combines options and options' do
     expect(subject.send(:combine_args, options_args1, options_args2)).to eq [{ minimum: 8, count: 12 }]
   end
 
-  it "merges options so that it prefers the passed in options" do
+  it 'merges options so that it prefers the passed in options' do
     array_options_args1[-1][:test_value] = 1
     array_options_args2[-1][:test_value] = 2
 
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-with-options-2", { visible: false, timeout: 30, test_value: 2 }]
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30, test_value: 2 }]
   end
 end

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -1,0 +1,100 @@
+require "spec_helper"
+
+RSpec.describe "#combine_args" do
+  class FakeContainerClass
+    include SitePrism::ElementContainer
+  end
+
+  let(:subject) { FakeContainerClass.new }
+  let(:array_args1) { rand(0..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") } }
+  let(:array_args2) { rand(0..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") } }
+  let(:options_args1) { [rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }] }
+  let(:options_args2) { [rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }] }
+  let(:array_options_args1) do
+    array = rand(1..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") }
+    array << rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }
+    array
+  end
+  let(:array_options_args2) do
+    array = rand(1..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") }
+    array << rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }
+    array
+  end
+
+  it "combines 2 arrays" do
+    expect(subject.send(:combine_args, array_args1, array_args2)).to eq [*array_args1, *array_args2, {}]
+  end
+
+  it "combines an array and options" do
+    expected_values = []
+    expected_values += array_args1
+    expected_values << options_args2[0]
+
+    expect(subject.send(:combine_args, array_args1, options_args2)).to eq expected_values
+  end
+
+  it "combines an array and an array with options" do
+    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [*array_args1, *array_options_args2]
+  end
+
+  it "combines an array with options and an array" do
+    expected_values = []
+    expected_values += array_options_args1[0..-2]
+    expected_values += array_args2
+    expected_values << array_options_args1[-1]
+
+    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq expected_values
+  end
+
+  it "combines an array with options and options" do
+    expected_values = []
+    expected_values += array_options_args1[0..-2]
+    expected_values << array_options_args1[-1].merge(options_args2[0])
+
+    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq expected_values
+  end
+
+  it "combines an array with options and an array with options" do
+    expected_values = []
+    expected_values += array_options_args1[0..-2]
+    expected_values += array_options_args2[0..-2]
+    expected_values << array_options_args1[-1].merge(array_options_args2[-1])
+
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq expected_values
+  end
+
+  it "combines options and an array" do
+    expected_values = []
+    expected_values += array_args2
+    expected_values << options_args1[0]
+
+    expect(subject.send(:combine_args, options_args1, array_args2)).to eq expected_values
+  end
+
+  it "combines options and an array with options" do
+    expected_values = []
+    expected_values += array_options_args2[0..-2]
+    expected_values << options_args1[0].merge(array_options_args2[-1])
+
+    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq expected_values
+  end
+
+  it "combines options and options" do
+    expected_values = []
+    expected_values << options_args1[0].merge(options_args2[0])
+
+    expect(subject.send(:combine_args, options_args1, options_args2)).to eq expected_values
+  end
+
+  it "merges options so that it prefers the passed in options" do
+    array_options_args1[-1][:test_value] = 1
+    array_options_args2[-1][:test_value] = 2
+    expected_values = []
+    expected_values += array_options_args1[0..-2]
+    expected_values += array_options_args2[0..-2]
+    expected_values << array_options_args1[-1].merge(array_options_args2[-1])
+
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq expected_values
+    expect(expected_values[-1][:test_value]).to eq 2
+  end
+end

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -26,23 +26,23 @@ RSpec.describe '#combine_args' do
   end
 
   it 'combines an array and an array with options' do
-    expect(subject.send(:combine_args, array_args1, array_options_args2)).
-      to eq [:css, '#argument-1', :css, '#argument-with-options-2', { timeout: 30 }]
+    expect(subject.send(:combine_args, array_args1, array_options_args2))
+      .to eq [:css, '#argument-1', :css, '#argument-with-options-2', { timeout: 30 }]
   end
 
   it 'combines an array with options and an array' do
-    expect(subject.send(:combine_args, array_options_args1, array_args2)).
-      to eq [:css, '#argument-with-options-1', :css, '#argument-2', { visible: false }]
+    expect(subject.send(:combine_args, array_options_args1, array_args2))
+      .to eq [:css, '#argument-with-options-1', :css, '#argument-2', { visible: false }]
   end
 
   it 'combines an array with options and options' do
-    expect(subject.send(:combine_args, array_options_args1, options_args2)).
-      to eq [:css, '#argument-with-options-1', { visible: false, count: 12 }]
+    expect(subject.send(:combine_args, array_options_args1, options_args2))
+      .to eq [:css, '#argument-with-options-1', { visible: false, count: 12 }]
   end
 
   it 'combines an array with options and an array with options' do
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).
-      to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30 }]
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2))
+      .to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30 }]
   end
 
   it 'combines options and an array' do
@@ -50,8 +50,8 @@ RSpec.describe '#combine_args' do
   end
 
   it 'combines options and an array with options' do
-    expect(subject.send(:combine_args, options_args1, array_options_args2)).
-      to eq [:css, '#argument-with-options-2', { minimum: 8, timeout: 30 }]
+    expect(subject.send(:combine_args, options_args1, array_options_args2))
+      .to eq [:css, '#argument-with-options-2', { minimum: 8, timeout: 30 }]
   end
 
   it 'combines options and options' do
@@ -62,7 +62,7 @@ RSpec.describe '#combine_args' do
     array_options_args1[-1][:test_value] = 1
     array_options_args2[-1][:test_value] = 2
 
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).
-      to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30, test_value: 2 }]
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2))
+      .to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30, test_value: 2 }]
   end
 end

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 RSpec.describe '#combine_args' do
   class FakeContainerClass
-    include SitePrism::ElementContainer
+    extend SitePrism::ElementContainer
   end
 
-  let(:subject) { FakeContainerClass.new }
+  let(:subject) { FakeContainerClass }
   let(:array_args1) { [:css, '#argument-1'] }
   let(:array_args2) { [:css, '#argument-2'] }
   let(:options_args1) { [{ minimum: 8 }] }

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -26,19 +26,23 @@ RSpec.describe '#combine_args' do
   end
 
   it 'combines an array and an array with options' do
-    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [:css, '#argument-1', :css, '#argument-with-options-2', { timeout: 30 }]
+    expect(subject.send(:combine_args, array_args1, array_options_args2)).
+      to eq [:css, '#argument-1', :css, '#argument-with-options-2', { timeout: 30 }]
   end
 
   it 'combines an array with options and an array' do
-    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-2', { visible: false }]
+    expect(subject.send(:combine_args, array_options_args1, array_args2)).
+      to eq [:css, '#argument-with-options-1', :css, '#argument-2', { visible: false }]
   end
 
   it 'combines an array with options and options' do
-    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq [:css, '#argument-with-options-1', { visible: false, count: 12 }]
+    expect(subject.send(:combine_args, array_options_args1, options_args2)).
+      to eq [:css, '#argument-with-options-1', { visible: false, count: 12 }]
   end
 
   it 'combines an array with options and an array with options' do
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30 }]
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).
+      to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30 }]
   end
 
   it 'combines options and an array' do
@@ -46,7 +50,8 @@ RSpec.describe '#combine_args' do
   end
 
   it 'combines options and an array with options' do
-    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq [:css, '#argument-with-options-2', { minimum: 8, timeout: 30 }]
+    expect(subject.send(:combine_args, options_args1, array_options_args2)).
+      to eq [:css, '#argument-with-options-2', { minimum: 8, timeout: 30 }]
   end
 
   it 'combines options and options' do
@@ -57,6 +62,7 @@ RSpec.describe '#combine_args' do
     array_options_args1[-1][:test_value] = 1
     array_options_args2[-1][:test_value] = 2
 
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30, test_value: 2 }]
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).
+      to eq [:css, '#argument-with-options-1', :css, '#argument-with-options-2', { visible: false, timeout: 30, test_value: 2 }]
   end
 end

--- a/spec/combine_args_spec.rb
+++ b/spec/combine_args_spec.rb
@@ -6,95 +6,57 @@ RSpec.describe "#combine_args" do
   end
 
   let(:subject) { FakeContainerClass.new }
-  let(:array_args1) { rand(0..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") } }
-  let(:array_args2) { rand(0..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") } }
-  let(:options_args1) { [rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }] }
-  let(:options_args2) { [rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }] }
-  let(:array_options_args1) do
-    array = rand(1..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") }
-    array << rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }
-    array
-  end
-  let(:array_options_args2) do
-    array = rand(1..5).times.map { rand(50..200).times.map { ('a'..'z').to_a.sample }.join("") }
-    array << rand(1..5).times.reduce({}) { |hash, _| hash[rand(5..20).times.map { ('a'..'z').to_a.sample }.join("")] = rand(50..200).times.map { ('a'..'z').to_a.sample }.join(""); hash }
-    array
-  end
+  let(:array_args1) { [:css, "#argument-1"] }
+  let(:array_args2) { [:css, "#argument-2"] }
+  let(:options_args1) { [{ minimum: 8 }] }
+  let(:options_args2) { [{ count: 12 }] }
+  let(:array_options_args1) { [:css, "#argument-with-options-1", { visible: false }] }
+  let(:array_options_args2) { [:css, "#argument-with-options-2", { timeout: 30 }] }
 
   it "combines 2 arrays" do
-    expect(subject.send(:combine_args, array_args1, array_args2)).to eq [*array_args1, *array_args2, {}]
+    expect(subject.send(:combine_args, array_args1, array_args2)).to eq [:css, "#argument-1", :css, "#argument-2", {}]
+  end
+
+  it "combines 2 arrays even if one is empty" do
+    expect(subject.send(:combine_args, array_args1, [])).to eq [:css, "#argument-1", {}]
   end
 
   it "combines an array and options" do
-    expected_values = []
-    expected_values += array_args1
-    expected_values << options_args2[0]
-
-    expect(subject.send(:combine_args, array_args1, options_args2)).to eq expected_values
+    expect(subject.send(:combine_args, array_args1, options_args2)).to eq [:css, "#argument-1", { count: 12 }]
   end
 
   it "combines an array and an array with options" do
-    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [*array_args1, *array_options_args2]
+    expect(subject.send(:combine_args, array_args1, array_options_args2)).to eq [:css, "#argument-1", :css, "#argument-with-options-2", { timeout: 30 }]
   end
 
   it "combines an array with options and an array" do
-    expected_values = []
-    expected_values += array_options_args1[0..-2]
-    expected_values += array_args2
-    expected_values << array_options_args1[-1]
-
-    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq expected_values
+    expect(subject.send(:combine_args, array_options_args1, array_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-2", { visible: false }]
   end
 
   it "combines an array with options and options" do
-    expected_values = []
-    expected_values += array_options_args1[0..-2]
-    expected_values << array_options_args1[-1].merge(options_args2[0])
-
-    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq expected_values
+    expect(subject.send(:combine_args, array_options_args1, options_args2)).to eq [:css, "#argument-with-options-1", { visible: false, count: 12 }]
   end
 
   it "combines an array with options and an array with options" do
-    expected_values = []
-    expected_values += array_options_args1[0..-2]
-    expected_values += array_options_args2[0..-2]
-    expected_values << array_options_args1[-1].merge(array_options_args2[-1])
-
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq expected_values
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-with-options-2", { visible: false, timeout: 30 }]
   end
 
   it "combines options and an array" do
-    expected_values = []
-    expected_values += array_args2
-    expected_values << options_args1[0]
-
-    expect(subject.send(:combine_args, options_args1, array_args2)).to eq expected_values
+    expect(subject.send(:combine_args, options_args1, array_args2)).to eq [:css, "#argument-2", { minimum: 8 }]
   end
 
   it "combines options and an array with options" do
-    expected_values = []
-    expected_values += array_options_args2[0..-2]
-    expected_values << options_args1[0].merge(array_options_args2[-1])
-
-    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq expected_values
+    expect(subject.send(:combine_args, options_args1, array_options_args2)).to eq [:css, "#argument-with-options-2", { minimum: 8, timeout: 30 }]
   end
 
   it "combines options and options" do
-    expected_values = []
-    expected_values << options_args1[0].merge(options_args2[0])
-
-    expect(subject.send(:combine_args, options_args1, options_args2)).to eq expected_values
+    expect(subject.send(:combine_args, options_args1, options_args2)).to eq [{ minimum: 8, count: 12 }]
   end
 
   it "merges options so that it prefers the passed in options" do
     array_options_args1[-1][:test_value] = 1
     array_options_args2[-1][:test_value] = 2
-    expected_values = []
-    expected_values += array_options_args1[0..-2]
-    expected_values += array_options_args2[0..-2]
-    expected_values << array_options_args1[-1].merge(array_options_args2[-1])
 
-    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq expected_values
-    expect(expected_values[-1][:test_value]).to eq 2
+    expect(subject.send(:combine_args, array_options_args1, array_options_args2)).to eq [:css, "#argument-with-options-1", :css, "#argument-with-options-2", { visible: false, timeout: 30, test_value: 2 }]
   end
 end


### PR DESCRIPTION
I like the options to pass parameters into the finders.

This allows me to create a definition like this:

```
class MyPage < SitePrism::Page
  elements :my_elements, ".my-class"
end
```

Then, if I have a `MyPage` object I can do something like:

```
my_page.my_elements(minimum: 12) # only return success if there are at least 12 items.
```

The problem I ran into is if I had the following definitions:

```
class MyPage < SitePrism::Page
  elements :my_visible_elements, ".my-class"
  elements :my_possible_elements, ".my-class", visible: false
end
```

Now, if I make this call, I don't get my expected results:

```
my_page.my_possible_elements(minimum: 12) # not quite right - will be the same as my_page.my_visible_elements(minimum: 12)
```

Instead, I would have to do:

```
my_page.my_possible_elements(minimum: 12, visible: false)
```

But this means that I have to know what the options were that were a part of the element definition.

This change merges the sets of values in the element definition with the values passed in to the defined object such that there is only one options hash that is a merge of the two.

This would now allow:

```
my_page.my_possible_elements(minimum: 12) # now, the options is { visible: false, minimum: 12 }
```
