### PR TITLE
Change Capybara.default_wait_time to Capybara.default_max_wait_time to fix deprecation warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ RuboCop::RakeTask.new
 
 namespace :docs do
   YARD::Rake::YardocTask.new :generate do |t|
-    t.files   = ['lib/**/*.rb', '-', 'README.md']
+    t.files = ['lib/**/*.rb', '-', 'README.md']
   end
 end
 

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -2,10 +2,10 @@ require 'site_prism/exceptions'
 require 'addressable/template'
 
 module SitePrism
-  autoload :ElementContainer,  'site_prism/element_container'
-  autoload :ElementChecker,  'site_prism/element_checker'
-  autoload :Page,  'site_prism/page'
-  autoload :Section,  'site_prism/section'
+  autoload :ElementContainer, 'site_prism/element_container'
+  autoload :ElementChecker, 'site_prism/element_checker'
+  autoload :Page, 'site_prism/page'
+  autoload :Section, 'site_prism/section'
   autoload :Waiter, 'site_prism/waiter'
   autoload :AddressableUrlMatcher, 'site_prism/addressable_url_matcher'
 

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -6,5 +6,5 @@ module SitePrism
   class TimeoutException < StandardError; end
   class TimeOutWaitingForElementVisibility < StandardError; end
   class TimeOutWaitingForElementInvisibility < StandardError; end
-  class UnsupportedBlock < StandardError;  end
+  class UnsupportedBlock < StandardError; end
 end

--- a/lib/site_prism/waiter.rb
+++ b/lib/site_prism/waiter.rb
@@ -11,7 +11,7 @@ module SitePrism
     end
 
     def self.default_wait_time
-      Capybara.default_wait_time
+      Capybara.default_max_wait_time
     end
   end
 end


### PR DESCRIPTION
The warning appears whilst running Cucumber with recent versions of Capybara. Also added some tidying up via Rubocop