### PR TITLE
Implement new Loadable behavior for pages and sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,6 +1217,143 @@ end
 @results_page.wait_for_search_results(10) #=> waits for 10 seconds instead of the default capybara timeout
 ```
 
+## Load Validations
+
+Load validations enable common validations to be abstracted and performed on a Page or Section to determine
+when it has finished loading and is ready for interaction in your tests.
+
+For example, suppose you have a page which displays a 'Loading...' message while the body of
+the page is loaded in the background.  Load validations can be used to ensure tests wait for the correct url
+to be displayed and the loading message removed before trying to interact with with the page.
+
+Other use cases include Sections which are displayed conditionally and may take time to become ready to
+interact with, such as animated lightboxes.
+
+### Using Load Validations
+
+Load validations can be used in three constructs:
+
+* Passing a block to `Page#load`
+* Passing a block to `Loadable#when_loaded`
+* Calling `Loadable#loaded?`
+
+#### Page#load
+
+When a block is passed to the `Page#load` method, the url will be loaded normally and then the block will be
+executed within the context of `when_loaded`.  See `when_loaded` documentation below for further details.
+
+Example:
+
+```ruby
+# Load the page and then execute a block after all load validations pass:
+my_page_instance.load do |page|
+  page.do_something
+end
+```
+
+#### Loadable#when_loaded
+
+The `Loadable#when_loaded` method on a Loadable class instance will yield the instance of the class into a
+block after all load validations have passed.
+
+If any load validation fails, an error will be raised with the reason, if given, for the failure.
+
+Example:
+
+```ruby
+# Execute a block after all load validations pass:
+a_loadable_page_or_section.when_loaded do |loadable|
+  loadable.do_something
+end
+```
+
+#### Loadable#loaded?
+
+You can explicitly run load validations on a Loadable via the `loaded?` method.
+This method will execute all load validations on the object and return a boolean value.
+In the event of a validation failure, a validation error can be accessed via the `load_error`
+method on the object, if any error message was emitted by the failing validation.
+
+Example:
+
+```ruby
+it 'loads the page' do
+  some_page.load
+  some_page.loaded?    #=> true if/when all load validations pass
+  another_page.loaded? #=> false if any load validations fail
+  another_page.load_error #=> A string error message if one was supplied by the failing load validation, or nil
+end
+```
+
+### Defining Load Validations
+
+A load validation is a block which returns a boolean value when evaluated against an instance of the Loadable.
+
+```ruby
+class SomePage < SitePrism::Page
+  element :foo_element, '.foo'
+  load_validation { has_foo_element? }
+end
+```
+
+The block may instead return a two-element array which includes the boolean result as the first element and an
+error message as the second element. It is highly recommended to supply an error message, as they are
+extremely useful in debugging validation errors.
+
+The error message will be ignored unless the boolean value is falsey.
+
+```ruby
+class SomePage < SitePrism::Page
+  element :foo_element, '.foo'
+  load_validation { [has_foo_element?, 'did not have foo element!'] }
+end
+```
+
+Load validations may be defined on `SitePrism::Page` and `SitePrism::Section` classes (herein referred
+to as `Loadables`) and are evaluated against an instance of the class when executed.
+
+### Load Validation Inheritance and Execution Order
+
+Any number of load validations may be defined on a Loadable class and will be inherited by its subclasses.
+
+Load validations are executed in the order that they are defined.  Inherited load validations are executed
+from the top of the inheritance chain (e.g. `SitePrism::Page` or `SitePrism::Section`) to the bottom.
+
+For example:
+
+```ruby
+class BasePage < SitePrism::Page
+  element :loading_message, '.loader'
+
+  load_validation do
+    wait_for_loading_message(1)
+    [ has_no_loading_message?(wait: 10), 'loading message was still displayed' ]
+  end
+end
+
+class FooPage < BasePage
+  set_url '/foo'
+
+  section :form, '#form'
+  element :some_other_element, '.myelement'
+
+  load_validation { [has_form?, 'form did not appear'] }
+  load_validation { [has_some_other_element?, 'some other element did not appear'] }
+end
+```
+
+In the above example, when `loaded?` is called on an instance of `FooPage`, the validations will be performed in the
+following order:
+
+1. The `SitePrism::Page` default load validation will check `displayed?`
+2. The `BasePage` load validation will wait for the loading message to disappear.
+3. The `FooPage` load validation will wait for the `form` element to be present.
+4. The `FooPage` load validation will wait for the `some_other_element` element to be present.
+
+NOTE: `SitePrism::Page` includes a default load validation on `page.displayed?` which is applied
+to all pages.  It is therefore not necessary to define a load validation for this condition on
+inheriting page objects.
+
 ## Using Capybara Query Options
 
 When querying an element, section or a collection of elements or sections, you may

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -7,4 +7,5 @@ module SitePrism
   class TimeOutWaitingForElementVisibility < StandardError; end
   class TimeOutWaitingForElementInvisibility < StandardError; end
   class UnsupportedBlock < StandardError; end
+  NotLoadedError = Class.new(StandardError)
 end

--- a/lib/site_prism/loadable.rb
+++ b/lib/site_prism/loadable.rb
@@ -1,0 +1,84 @@
+module SitePrism
+  module Loadable
+    module ClassMethods
+      # The list of load_validations.  They will be executed in the order they are defined.
+      #
+      # @return [Array]
+      def load_validations
+        if superclass.respond_to?(:load_validations)
+          superclass.load_validations + _load_validations
+        else
+          _load_validations
+        end
+      end
+
+      # Appends a load validation block to the page class.
+      #
+      # When `loaded?` is called, these blocks are instance_eval'd against the current page
+      # instance.  This allows users to wait for specific events to occur on the page or certain elements
+      # to be loaded before performing any actions on the page.
+      #
+      # @param block [&block] A block which returns true if the page loaded successfully, or false if it did not.
+      def load_validation(&block)
+        _load_validations << block
+      end
+
+      def _load_validations
+        @_load_validations ||= []
+      end
+      private :_load_validations
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # In certain circumstances, we cache that the page has already been confirmed to be loaded so that actions which
+    # call `loaded?` a second time do not need to perform the load_validation queries against the page a second time.
+    attr_accessor :loaded, :load_error
+
+    # Executes the given block after the page is loaded.
+    #
+    # The loadable object instance is yielded into the block.
+    #
+    # @param block [&block] The block to be executed once the page has finished loading.
+    def when_loaded(&block)
+      previously_loaded = self.loaded # Get original loaded value, in case we are nested inside another when_loaded block.
+      raise ArgumentError unless block_given?
+
+      # Within the block, cache loaded? to optimize performance.
+      unless self.loaded = loaded?
+        message = "Failed to load because: #{load_error || 'no reason given'}"
+        raise ::SitePrism::NotLoadedError.new(message)
+      end
+
+      yield self
+    ensure
+      self.loaded = previously_loaded
+    end
+
+    # Check if the page is loaded.
+    #
+    # On failure, if an error was reported by a failing validation, it will be available via the `load_error` accessor.
+    #
+    # @return [Boolean] True if the page loaded successfully; otherwise false.
+    def loaded?
+      self.load_error = nil
+
+      return true if loaded
+
+      load_validations_pass?
+    end
+
+    # If any load validations from page subclasses returns false, immediately return false.
+    def load_validations_pass?
+      self.class.load_validations.all? do |validation|
+        passed, message = instance_eval(&validation)
+
+        self.load_error = message if message && !passed
+        passed
+      end
+    end
+    private :load_validations_pass?
+  end
+end

--- a/lib/site_prism/loadable.rb
+++ b/lib/site_prism/loadable.rb
@@ -43,16 +43,16 @@ module SitePrism
     #
     # @param block [&block] The block to be executed once the page has finished loading.
     def when_loaded(&block)
-      previously_loaded = self.loaded # Get original loaded value, in case we are nested inside another when_loaded block.
-      raise ArgumentError unless block_given?
+      previously_loaded = loaded # Get original loaded value, in case we are nested inside another when_loaded block.
+      fail(ArgumentError, 'A block was expected, but none received.') unless block_given?
 
       # Within the block, cache loaded? to optimize performance.
       unless self.loaded = loaded?
         message = "Failed to load because: #{load_error || 'no reason given'}"
-        raise ::SitePrism::NotLoadedError.new(message)
+        fail(::SitePrism::NotLoadedError, message)
       end
 
-      yield self
+      block.call self
     ensure
       self.loaded = previously_loaded
     end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -1,20 +1,38 @@
+require 'site_prism/loadable'
+
 module SitePrism
   class Page
     include Capybara::DSL
     include ElementChecker
+    include Loadable
     extend ElementContainer
+
+    load_validation do
+      [ displayed?, "Expected #{current_url} to match #{url_matcher} but it did not." ]
+    end
 
     def page
       @page || Capybara.current_session
     end
 
-    def load(expansion_or_html = {})
+    # Loads the page.
+    # Executes the block, if given, after running load validations on the page.
+    #
+    # @param expansion_or_html
+    # @param block [&block] A block to run once the page is loaded.  The page will yield itself into the block.
+    def load(expansion_or_html = {}, &block)
+      self.loaded = false
+
       if expansion_or_html.is_a? String
         @page = Capybara.string(expansion_or_html)
       else
         expanded_url = url(expansion_or_html)
         fail SitePrism::NoUrlForPage if expanded_url.nil?
         visit expanded_url
+      end
+
+      if block_given?
+        when_loaded(&block)
       end
     end
 

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -8,7 +8,7 @@ module SitePrism
     extend ElementContainer
 
     load_validation do
-      [ displayed?, "Expected #{current_url} to match #{url_matcher} but it did not." ]
+      [displayed?, "Expected #{current_url} to match #{url_matcher} but it did not."]
     end
 
     def page
@@ -31,9 +31,7 @@ module SitePrism
         visit expanded_url
       end
 
-      if block_given?
-        when_loaded(&block)
-      end
+      when_loaded(&block) if block_given?
     end
 
     def displayed?(*args)

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -1,7 +1,10 @@
+require 'site_prism/loadable'
+
 module SitePrism
   class Section
     include Capybara::DSL
     include ElementChecker
+    include Loadable
     extend ElementContainer
 
     attr_reader :root_element, :parent

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'site_prism/loadable'
 
 describe SitePrism::Loadable do
-
   let(:loadable) do
     Class.new do
       include SitePrism::Loadable
@@ -27,7 +26,7 @@ describe SitePrism::Loadable do
         subclass.load_validation(&validation_3)
         loadable.load_validation(&validation_4)
 
-        expect(subclass.load_validations).to eql [validation_2, validation_4, validation_1, validation_3 ]
+        expect(subclass.load_validations).to eql [validation_2, validation_4, validation_1, validation_3]
       end
     end
 
@@ -50,7 +49,7 @@ describe SitePrism::Loadable do
       expect(instance).to receive(:foo)
 
       instance.when_loaded do |l|
-        l.foo
+        l.foo && true
       end
     end
 
@@ -60,9 +59,9 @@ describe SitePrism::Loadable do
       loadable.load_validation { true }
       loadable.load_validation { false }
 
-      expect {
+      expect do
         loadable.new.when_loaded { james_bond.drink_martini }
-      }.to raise_error(SitePrism::NotLoadedError, /no reason given/)
+      end.to raise_error(SitePrism::NotLoadedError, /no reason given/)
 
       expect(james_bond).not_to have_received(:drink_martini)
     end
@@ -70,9 +69,9 @@ describe SitePrism::Loadable do
     it 'raises an exception with specific error message if available when a load validation fails' do
       loadable.load_validation { [false, 'all your base are belong to us'] }
 
-      expect {
+      expect do
         loadable.new.when_loaded { puts 'foo' }
-      }.to raise_error(SitePrism::NotLoadedError, /all your base are belong to us/)
+      end.to raise_error(SitePrism::NotLoadedError, /all your base are belong to us/)
     end
 
     it 'raises immediately on the first validation failure' do
@@ -82,9 +81,9 @@ describe SitePrism::Loadable do
       loadable.load_validation { validation_spy_1.valid? }
       loadable.load_validation { validation_spy_2.valid? }
 
-      expect {
+      expect do
         loadable.new.when_loaded { puts 'foo' }
-      }.to raise_error(SitePrism::NotLoadedError)
+      end.to raise_error(SitePrism::NotLoadedError)
 
       expect(validation_spy_1).to have_received(:valid?).once
       expect(validation_spy_2).not_to have_received(:valid?)
@@ -115,9 +114,9 @@ describe SitePrism::Loadable do
       instance = loadable.new
       expect(instance.loaded).to be nil
 
-      instance.when_loaded { |i|
+      instance.when_loaded do |i|
         expect(i.loaded).to be true
-      }
+      end
 
       expect(instance.loaded).to be nil
     end

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -1,0 +1,178 @@
+require 'spec_helper'
+require 'site_prism/loadable'
+
+describe SitePrism::Loadable do
+
+  let(:loadable) do
+    Class.new do
+      include SitePrism::Loadable
+
+      def foo
+        :foo
+      end
+    end
+  end
+
+  describe 'class methods' do
+    describe '#load_validations' do
+      it 'returns the load_validations from the current and all ancestral classes in hierarchical, defined order' do
+        subclass = Class.new(loadable)
+        validation_1 = -> { true }
+        validation_2 = -> { true }
+        validation_3 = -> { true }
+        validation_4 = -> { true }
+
+        subclass.load_validation(&validation_1)
+        loadable.load_validation(&validation_2)
+        subclass.load_validation(&validation_3)
+        loadable.load_validation(&validation_4)
+
+        expect(subclass.load_validations).to eql [validation_2, validation_4, validation_1, validation_3 ]
+      end
+    end
+
+    describe '#load_validation' do
+      it 'adds validations to the load_validations list' do
+        expect { loadable.load_validation { true } }.to change { loadable.load_validations.size }.by(1)
+      end
+    end
+  end
+
+  describe '#when_loaded' do
+    it 'raises if no block given' do
+      expect { loadable.new.when_loaded }.to raise_error ArgumentError
+    end
+
+    it 'executes and yields itself to the provided block when all load validations pass' do
+      loadable.load_validation { true }
+      instance = loadable.new
+
+      expect(instance).to receive(:foo)
+
+      instance.when_loaded do |l|
+        l.foo
+      end
+    end
+
+    it 'raises an exception if any load validation fails' do
+      james_bond = spy
+
+      loadable.load_validation { true }
+      loadable.load_validation { false }
+
+      expect {
+        loadable.new.when_loaded { james_bond.drink_martini }
+      }.to raise_error(SitePrism::NotLoadedError, /no reason given/)
+
+      expect(james_bond).not_to have_received(:drink_martini)
+    end
+
+    it 'raises an exception with specific error message if available when a load validation fails' do
+      loadable.load_validation { [false, 'all your base are belong to us'] }
+
+      expect {
+        loadable.new.when_loaded { puts 'foo' }
+      }.to raise_error(SitePrism::NotLoadedError, /all your base are belong to us/)
+    end
+
+    it 'raises immediately on the first validation failure' do
+      validation_spy_1 = spy(valid?: false)
+      validation_spy_2 = spy(valid?: false)
+
+      loadable.load_validation { validation_spy_1.valid? }
+      loadable.load_validation { validation_spy_2.valid? }
+
+      expect {
+        loadable.new.when_loaded { puts 'foo' }
+      }.to raise_error(SitePrism::NotLoadedError)
+
+      expect(validation_spy_1).to have_received(:valid?).once
+      expect(validation_spy_2).not_to have_received(:valid?)
+    end
+
+    it 'executes validations only once for nested calls' do
+      james_bond = spy
+      validation_spy_1 = spy(valid?: true)
+
+      loadable.load_validation { validation_spy_1.valid? }
+      instance = loadable.new
+
+      instance.when_loaded do
+        instance.when_loaded do
+          instance.when_loaded do
+            james_bond.drink_martini
+          end
+        end
+      end
+
+      expect(james_bond).to have_received(:drink_martini)
+      expect(validation_spy_1).to have_received(:valid?).once
+    end
+
+    it 'resets the loaded cache at the end of the block' do
+      loadable.load_validation { true }
+
+      instance = loadable.new
+      expect(instance.loaded).to be nil
+
+      instance.when_loaded { |i|
+        expect(i.loaded).to be true
+      }
+
+      expect(instance.loaded).to be nil
+    end
+  end
+
+  describe '#loaded?' do
+    # We want to test with multiple inheritance
+    let(:inheriting_loadable) { Class.new(loadable) }
+
+    it 'returns true if loaded value is cached' do
+      validation_spy_1 = spy(valid?: true)
+      loadable.load_validation { validation_spy_1.valid? }
+      instance = loadable.new
+      instance.loaded = true
+
+      expect(instance).to be_loaded
+      expect(validation_spy_1).not_to have_received(:valid?)
+    end
+
+    it 'returns true if all load validations pass' do
+      loadable.load_validation { true }
+      loadable.load_validation { true }
+      inheriting_loadable.load_validation { true }
+      inheriting_loadable.load_validation { true }
+
+      expect(inheriting_loadable.new).to be_loaded
+    end
+
+    it 'returns false if any load validation fails' do
+      loadable.load_validation { true }
+      loadable.load_validation { true }
+      inheriting_loadable.load_validation { true }
+      inheriting_loadable.load_validation { false }
+
+      expect(inheriting_loadable.new).not_to be_loaded
+    end
+
+    it 'returns false if any load validation fails at any point in the inheritance chain' do
+      loadable.load_validation { true }
+      loadable.load_validation { false }
+      inheriting_loadable.load_validation { true }
+      inheriting_loadable.load_validation { true }
+
+      expect(inheriting_loadable.new).not_to be_loaded
+    end
+
+    it 'sets load_error if a failing load_validation supplies one' do
+      loadable.load_validation { [true, 'this cannot fail'] }
+      loadable.load_validation { [false, 'fubar'] }
+      inheriting_loadable.load_validation { [true, 'this also cannot fail'] }
+      inheriting_loadable.load_validation { [true, 'this also also cannot fail'] }
+
+      instance = inheriting_loadable.new
+      instance.loaded?
+      expect(instance.load_error).to eql 'fubar'
+    end
+  end
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -28,35 +28,91 @@ describe SitePrism::Page do
     expect(page.url).to be_nil
   end
 
-  it "should not allow loading if the url hasn't been set" do
-    class MyPageWithNoUrl < SitePrism::Page; end
-    page_with_no_url = MyPageWithNoUrl.new
-    expect { page_with_no_url.load }.to raise_error(SitePrism::NoUrlForPage)
-  end
-
-  it 'should allow loading if the url has been set' do
-    class MyPageWithUrl < SitePrism::Page
-      set_url '/bob'
+  describe 'loaded?' do
+    it 'is true if displayed' do
+      page = SitePrism::Page.new
+      allow(page).to receive(:displayed?).and_return true
+      expect(page).to be_loaded
     end
-    page_with_url = MyPageWithUrl.new
-    expect { page_with_url.load }.to_not raise_error
-  end
 
-  it 'should allow expansions if the url has them' do
-    class MyPageWithUriTemplate < SitePrism::Page
-      set_url '/users{/username}{?query*}'
+    it 'is false if not displayed' do
+      page = SitePrism::Page.new
+      allow(page).to receive(:displayed?).and_return false
+      expect(page).not_to be_loaded
     end
-    page_with_url = MyPageWithUriTemplate.new
-    expect { page_with_url.load(username: 'foobar') }.to_not raise_error
-    expect(page_with_url.url(username: 'foobar', query: { 'recent_posts' => 'true' })).to eq('/users/foobar?recent_posts=true')
-    expect(page_with_url.url(username: 'foobar')).to eq('/users/foobar')
-    expect(page_with_url.url).to eq('/users')
   end
 
-  it 'should allow to load html' do
-    class Page < SitePrism::Page; end
-    page = Page.new
-    expect { page.load('<html/>') }.to_not raise_error
+  describe '#load' do
+    it "should not allow loading if the url hasn't been set" do
+      class MyPageWithNoUrl < SitePrism::Page; end
+      page_with_no_url = MyPageWithNoUrl.new
+      expect { page_with_no_url.load }.to raise_error(SitePrism::NoUrlForPage)
+    end
+
+    it 'should allow loading if the url has been set' do
+      class MyPageWithUrl < SitePrism::Page
+        set_url '/bob'
+      end
+      page_with_url = MyPageWithUrl.new
+      expect { page_with_url.load }.to_not raise_error
+    end
+
+    it 'should allow expansions if the url has them' do
+      class MyPageWithUriTemplate < SitePrism::Page
+        set_url '/users{/username}{?query*}'
+      end
+      page_with_url = MyPageWithUriTemplate.new
+      expect { page_with_url.load(username: 'foobar') }.to_not raise_error
+      expect(page_with_url.url(username: 'foobar', query: { 'recent_posts' => 'true' })).to eq('/users/foobar?recent_posts=true')
+      expect(page_with_url.url(username: 'foobar')).to eq('/users/foobar')
+      expect(page_with_url.url).to eq('/users')
+    end
+
+    it 'should allow to load html' do
+      class Page < SitePrism::Page; end
+      page = Page.new
+      expect { page.load('<html/>') }.to_not raise_error
+    end
+
+    context 'when passed a block' do
+      let(:page_klass_with_load_validations) do
+        Class.new(SitePrism::Page) do
+          set_url '/foo_page'
+
+          def is_true?
+            true
+          end
+
+          def is_also_true?
+            true
+          end
+
+          def foo?
+            true
+          end
+
+          load_validation { [ is_true?, 'It is not true!' ] }
+          load_validation { [ is_also_true?, 'It is not also true!' ] }
+        end
+      end
+
+      it 'executes a block when load validations pass' do
+        page = page_klass_with_load_validations.new
+        expect { page.load { true } }.not_to raise_error
+      end
+
+      it 'yields itself to the passed block' do
+        page = page_klass_with_load_validations.new
+        expect(page).to receive(:foo?)
+        page.load { |p| p.foo? }
+      end
+
+      it 'raises an error when a block passed and load validations fail' do
+        page = page_klass_with_load_validations.new
+        expect(page).to receive(:is_true?).and_return(false)
+        expect { page.load { puts 'foo' } }.to raise_error(SitePrism::NotLoadedError, /It is not true!/)
+      end
+    end
   end
 
   it 'should respond to set_url_matcher' do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -79,11 +79,11 @@ describe SitePrism::Page do
         Class.new(SitePrism::Page) do
           set_url '/foo_page'
 
-          def is_true?
+          def must_be_true
             true
           end
 
-          def is_also_true?
+          def also_true
             true
           end
 
@@ -91,8 +91,8 @@ describe SitePrism::Page do
             true
           end
 
-          load_validation { [ is_true?, 'It is not true!' ] }
-          load_validation { [ is_also_true?, 'It is not also true!' ] }
+          load_validation { [must_be_true, 'It is not true!'] }
+          load_validation { [also_true, 'It is not also true!'] }
         end
       end
 
@@ -104,12 +104,12 @@ describe SitePrism::Page do
       it 'yields itself to the passed block' do
         page = page_klass_with_load_validations.new
         expect(page).to receive(:foo?)
-        page.load { |p| p.foo? }
+        page.load { |p| p.foo? && true }
       end
 
       it 'raises an error when a block passed and load validations fail' do
         page = page_klass_with_load_validations.new
-        expect(page).to receive(:is_true?).and_return(false)
+        expect(page).to receive(:must_be_true).and_return(false)
         expect { page.load { puts 'foo' } }.to raise_error(SitePrism::NotLoadedError, /It is not true!/)
       end
     end


### PR DESCRIPTION
@natritmeyer 

This PR adds a fully backwards compatible feature I call 'load validations' to SitePrism which we have been using internally for a while now with great success.  It provides a common abstraction for dealing with asynchronous behavior on pages, which can be a significant source of intermittent failures due to waiting for elements to be displayed.

This allows you to very cleanly abstract all of your waiting logic to a single place with a common pattern, and even allows for common validation logic to be shared between page if needed.  Additionally, it makes it very easy and clean to encapsulate this behavior in your tests without spreading boilerplate code throughout them.

The PR has thorough documentation and tests, please take a look.  I have additionally run our entire acceptance test suite against a branch of our SitePrism fork containing these changes, with the implementation of this in our test suite having been removed.

I can provide a more thorough contrived example if needed, but the basic gist assuming you have some pages defined with load validations is this:

```ruby
it 'does something' do
  home_page.load do |page|
    # Passing a block to the load method loads the page as usual,
    # then implicitly runs load validations before executing the block.
    # Existing functionality of the `load` method is not affected.
    page.register_button.click
  end

  registration_page.when_loaded do |page|
    # The page instance is yielded into the `load` and `when_loaded` blocks.  This allows you to cleanly encapsulate
    # interactions with each page, which is especially nice when performing multiple interactions
    # with a single page.
    page.email.set 'foo@example.test'
    page.password.set 'hunter2'
    page.submit
  end
  
  # Here we call a helper method on a page object which uses when_loaded to allow this to be executed as a one-liner in the test:
  another_page_with_a_form.fill_and_submit

  yet_another_page.when_loaded do |page|
    # Here we call a series of helper methods and/or element interactions on the page object.
    # Some of these methods may wrap their implementation in `when_loaded` blocks so that they
    # can be used safely as either a one-liner in a test, or as part of a larger construct as it is here.
    # The load caching in the Loaded module makes these nested calls extremely efficient, as only
    # the outermost `when_loaded` call actually execute the load validations while inner calls use the
    # cached result of the outermost block.
    page.do_thing_1
    page.do_thing_2
    page.complete
  end
end
```

We have found this to be very useful because:
* It removes boilerplate code for page readiness checks such as `page.displayed?` and/or testing for element existence in tests and/or helper methods prior to interacting with a page.
* It avoids nested/duplicate page readiness checks in test and helper methods, which incur a performance hit performing multiple duplicate queries against the driver.
* It provides a single, common abstraction for handling and using load validations for every page object.
* It makes our tests very clean with obvious scoping for the interactions with each page

I additionally believe this is a sufficient solution for issues #48, #49, and #50, as it enables users to define how they want a page to be tested for readiness which may include checks of 0 or more elements as needed and may include recursive checks against sections which may additionally provide their own load validations if desired.

It is also much more efficient and useful than `all_there?`, which does not provide an implicit wait mechanism and is a sledgehammer where a scalpel is needed.  Checking for all elements when testing if a page is ready for interaction under normal circumstances incurs a significant negative performance penalty for all tests that use it, where testing for URL and usually one or two elements is usually sufficient.

Please let me know your thoughts and comments.  From a functional standpoint, this PR is fully backwards-compatible, fully tested, thoroughly documented and should be ready to merge pending your approval.

Cheers!