### PR TITLE
Page wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,19 @@ class SlowLoadingPage < SitePrism::Page
 end
 ```
 
+The wait time is also inherited from superclasses. For example:
+
+```ruby
+class SlowLoadingBasePage < SitePrism::Page
+  set_page_wait_time 10
+end
+
+class SlowLoadingPage < SlowLoadingBasePage
+end
+
+SlowLoadingPage.new.displayed? # => waits up to 10 seconds to be displayed
+```
+
 Note that this can still be overriden by passing a wait time argument to *displayed?*, e.g: `displayed?(1)`
 
 ### Navigating to the Page

--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ end
 
 See https://github.com/sporkmonger/addressable for more details on parameterized URLs.
 
+### Adding a wait time
+
+Sometimes complex processing between pages causes a certain page to take a long time to be displayed.
+If you want the *displayed?* method to automatically wait longer than the default, here's how:
+
+```ruby
+class SlowLoadingPage < SitePrism::Page
+  set_page_wait_time 10
+end
+```
+
+Note that this can still be overriden by passing a wait time argument to *displayed?*, e.g: `displayed?(1)`
+
 ### Navigating to the Page
 
 Once the URL has been set (using `set_url`), you can navigate directly

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -20,7 +20,7 @@ module SitePrism
 
     def displayed?(*args)
       expected_mappings = args.last.is_a?(::Hash) ? args.pop : {}
-      seconds = args.length > 0 ? args.first : Waiter.default_wait_time
+      seconds = args.length > 0 ? args.first : self.class.page_wait_time
       fail SitePrism::NoUrlMatcherForPage if url_matcher.nil?
       begin
         Waiter.wait_until_true(seconds) { url_matches?(expected_mappings) }
@@ -75,6 +75,20 @@ module SitePrism
     def secure?
       !current_url.match(/^https/).nil?
     end
+
+    def self.set_page_wait_time(seconds)
+      @page_wait_time = seconds
+    end
+
+    def self.page_wait_time
+      @page_wait_time ||= ancestral_wait_time
+    end
+
+    def self.ancestral_wait_time
+      return Waiter.default_wait_time unless superclass.respond_to? :page_wait_time
+      superclass.page_wait_time
+    end
+    private_class_method :ancestral_wait_time
 
     private
 


### PR DESCRIPTION
While SitePrism has the concept of a default wait time, it doesn't allow pages to specify a wait time separately from sections/elements. So, this PR adds a feature that allows a page to have it's own **page_wait_time**. Tests and brief documentation are included. Here's an pseudo-example:

``` ruby
# first_page.rb
class FirstPage < SitePrism::Page
  # no page wait time defined, uses SitePrism::Waiter.default_wait_time
end

# second_page.rb
class SecondPage < SitePrism::Page
  set_page_wait_time 30
end

# some_spec.rb
first_page.submit                   # => complex processing after submit, takes ~20 seconds
expect(second_page).to be_displayed # => waits up to 30 seconds for the page to be displayed

# some_other_other_spec.rb
first_page.submit                      # => no complex processing for some reason, maybe an error on the form
expect(second_page) to be_displayed(1) # => overrides the page_wait_time, and waits only 1 second
```
