### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ that should be used to test for non-existence. Using the above example:
 
 ```ruby
 Then /^the search field exists$/ do
-  expect(@home).to have_no_search_field #NB: NOT => expect(@home).not_to_ have_search_field
+  expect(@home).to have_no_search_field #NB: NOT => expect(@home).not_to have_search_field
 end
 ```
 


### PR DESCRIPTION
I remember this confused me the first time I read it since I was thinking that the `NOT` in the comment refers to the syntax of `not_to` so I was thinking "what? of course it is not `not_to_`" ;)