### PR TITLE
add implicit waits to the #all_there? check if they're enabled

### DIFF
--- a/lib/site_prism/element_checker.rb
+++ b/lib/site_prism/element_checker.rb
@@ -1,7 +1,8 @@
 module SitePrism
   module ElementChecker
     def all_there?
-      Capybara.using_wait_time(0) do
+      wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
+      Capybara.using_wait_time(wait_time) do
         self.class.mapped_items.all? { |element| send "has_#{element}?" }
       end
     end


### PR DESCRIPTION
`use_implicit_waits` is a lifesaver for my particular usage of SitePrism. Its implementation should be more consistent. :)