### PR TITLE
fixed rspec 3 method name collision

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -6,7 +6,7 @@ module SitePrism
       build element_name, *find_args do
         define_method element_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-          root_element.find_first(*find_args, *runtime_args)
+          root_element.first(*find_args, *runtime_args)
         end
       end
     end
@@ -15,7 +15,7 @@ module SitePrism
       build collection_name, *find_args do
         define_method collection_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-          root_element.find_all(*find_args, *runtime_args)
+          root_element.all(*find_args, *runtime_args)
         end
       end
     end
@@ -26,7 +26,7 @@ module SitePrism
       build section_name, *find_args do
         define_method section_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
-          section_class.new self, root_element.find_first(*find_args, *runtime_args)
+          section_class.new self, root_element.first(*find_args, *runtime_args)
         end
       end
     end
@@ -36,7 +36,7 @@ module SitePrism
       build section_collection_name, *find_args do
         define_method section_collection_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
-          root_element.find_all(*find_args, *runtime_args).map do |element|
+          root_element.all(*find_args, *runtime_args).map do |element|
             section_class.new self, element
           end
         end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -6,7 +6,7 @@ module SitePrism
       build element_name, *find_args do
         define_method element_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-          find_first(*find_args, *runtime_args)
+          root_element.find_first(*find_args, *runtime_args)
         end
       end
     end
@@ -15,7 +15,7 @@ module SitePrism
       build collection_name, *find_args do
         define_method collection_name.to_s do |*runtime_args, &element_block|
           self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args)
+          root_element.find_all(*find_args, *runtime_args)
         end
       end
     end
@@ -26,7 +26,7 @@ module SitePrism
       build section_name, *find_args do
         define_method section_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_name.to_s, !element_block.nil?)
-          section_class.new self, find_first(*find_args, *runtime_args)
+          section_class.new self, root_element.find_first(*find_args, *runtime_args)
         end
       end
     end
@@ -36,7 +36,7 @@ module SitePrism
       build section_collection_name, *find_args do
         define_method section_collection_name do |*runtime_args, &element_block|
           self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args).map do |element|
+          root_element.find_all(*find_args, *runtime_args).map do |element|
             section_class.new self, element
           end
         end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -15,6 +15,10 @@ module SitePrism
       @page || Capybara.current_session
     end
 
+    def root_element
+      self.page
+    end
+
     # Loads the page.
     # Executes the block, if given, after running load validations on the page.
     #

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -16,7 +16,7 @@ module SitePrism
     end
 
     def root_element
-      self.page
+      page
     end
 
     # Loads the page.


### PR DESCRIPTION
I ran into the same issues as people in #95 and #102. These changes fix the name collision by explicitly selecting the recipient of the method call.
I'm not an expert with the inner workings of this gem and Capybara, so please let me know if I missed something.