### PR TITLE
Accessing a section's full text, HTML tag fixes

### DIFF
--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -85,3 +85,7 @@ Feature: Page Sections
   Scenario: Page with deeply nested sections
     When I navigate to the section experiments page
     Then the page contains a deeply nested span
+
+  Scenario: get text from page secion
+    When I navigate to the home page
+    Then I can see a section's full text 

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -140,3 +140,8 @@ Then(/^the page contains a deeply nested span$/) do
   expect(@test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0]).to have_deep_span
   expect(@test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0].deep_span.text).to eq 'Deep span'
 end
+
+Then(/^I can see a section's full text$/) do
+  expect(@test_site.home.people.text).to eq 'People person 1 person 2 person 3 person 4'
+  expect(@test_site.home.container_with_element.text).to eq ''
+end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -19,6 +19,10 @@ module SitePrism
       root_element.visible?
     end
 
+    def text
+      root_element.text
+    end
+
     def execute_script(input)
       Capybara.current_session.execute_script input
     end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>Home Page</title>
@@ -36,14 +37,13 @@
     <p>
       <a href='search.htm'>Search Page</a>
     </p>
-    <p>
-      <table>
-        <tr>
-          <td><a href='a.htm'>a</a></td>
-          <td><a href='b.htm'>b</a></td>
-          <td><a href='c.htm'>c</a></td>
-      </table>
-    </p>
+    <table>
+      <tr>
+        <td><a href='a.htm'>a</a></td>
+        <td><a href='b.htm'>b</a></td>
+        <td><a href='c.htm'>c</a></td>
+      </tr>
+    </table>
 
     <article class='people'>
       <h1>People</h1>
@@ -57,7 +57,8 @@
 
     <div id='container_with_element'>
       <div class='embedded_element'>
-    <end>
+      </div>
+    </div>
 
     <p id='dumping_ground'>
 
@@ -67,6 +68,6 @@
     <input type='submit' id='will_become_invisible' value='Will become invisible' style='display: block;'/>
     <input type='submit' class='invisible' value='Invisible' style='display: none;'/>
 
-    <iframe id='the_iframe' src='my_iframe.htm' />
+    <iframe id='the_iframe' src='my_iframe.htm'></iframe>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a `#text` method to the Section class. The method returns
all of the text within a section. Without this method, calling `#text` on a
section would return all of the text on the page.

This PR also addresses minor issues with closing tags in the test site.
HTML tags were appearing when `page.text` was called on the test site
due to several missing tags.