### PR TITLE
fixed method name collision with rspec

### DIFF
--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -89,25 +89,25 @@ module SitePrism
     end
 
     def secure?
-      current_url.start_with? 'https'
+      page.current_url.start_with? 'https'
     end
 
     private
 
     def find_first(*find_args)
-      find(*find_args)
+      page.find(*find_args)
     end
 
     def find_all(*find_args)
-      all(*find_args)
+      page.all(*find_args)
     end
 
     def element_exists?(*find_args)
-      has_selector?(*find_args)
+      page.has_selector?(*find_args)
     end
 
     def element_does_not_exist?(*find_args)
-      has_no_selector?(*find_args)
+      page.has_no_selector?(*find_args)
     end
 
     def url_matches?(expected_mappings = {})

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -10,10 +10,17 @@ describe SitePrism::Page do
     end
 
     class YetAnotherPageWithSections < SitePrism::Page
-      section :some_things, SomePageWithSectionsThatNeedsTestingForExistence, '.bob'
+      # in order to test method name collisions with rspec, we'll include its matchers
+      include RSpec::Matchers
+
+      section  :some_things,  SomePageWithSectionsThatNeedsTestingForExistence, '.bob'
+      sections :other_things, SomePageWithSectionsThatNeedsTestingForExistence, '.tim'
     end
 
     page = YetAnotherPageWithSections.new
     expect(page).to respond_to :has_some_things?
+    expect(page).to respond_to :has_other_things?
+    # will throw a NoMethodError if methods overwritten by rspec matchers are called
+    expect { page.other_things }.not_to raise_error
   end
 end


### PR DESCRIPTION
I ran into the same issues as people in #95 and #102. These changes fix the name collision by explicitly selecting the `page` as the recipient of the method calls.
This only fixes the name collisions I ran into, not sure if there more locations where this happens.
Please let me know what you think!