### PR TITLE
Improve find_first method to use first method from capybara

### DIFF
--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -42,7 +42,7 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      root_element.find(*find_args)
+      root_element.first(*find_args)
     end
 
     def find_all(*find_args)


### PR DESCRIPTION
Today when we use `element` in a section the SitePrism use capybara `find` method and raise an error if found more than 1 element, like that:

```
Capybara::Ambiguous: Ambiguous match, found 2 elements matching css "p.foobar"
```

My patch change the `find_first` method to use the method [`first`](http://www.rubydoc.info/github/jnicklas/capybara/Capybara/Node/Finders#find-instance_method) from capybara instead of `find`
