### PR TITLE
Updated checks for find_all

### DIFF
--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -95,12 +95,12 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      page.find(*find_args, wait: Capybara.default_max_wait_time)
+      page.find(*find_args)
     end
 
     def find_all(*find_args)
       page.find(*find_args, match: :first)
-      page.all(*find_args, Capybara.default_max_wait_time)
+      page.all(*find_args)
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -95,12 +95,12 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      page.find(*find_args, wait: 25)
+      page.find(*find_args, wait: Capybara.default_max_wait_time)
     end
 
     def find_all(*find_args)
       page.find(*find_args, match: :first)
-      page.all(*find_args, wait: 25)
+      page.all(*find_args, Capybara.default_max_wait_time)
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -95,11 +95,12 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      page.find(*find_args)
+      page.find(*find_args, wait: 25)
     end
 
     def find_all(*find_args)
-      page.all(*find_args)
+      page.find(*find_args, match: :first)
+      page.all(*find_args, wait: 25)
     end
 
     def element_exists?(*find_args)


### PR DESCRIPTION
Added a check for element to exist before looking for all

> Good:
> 
> find(".active", match: :first)
> all(".active").each(&:click)
> Capybara will wait for the first matching element before trying to click on the rest.
> 
> Note: there is usually a better way to test things than iterating over matching elements, but that is beyond the scope of this post. Think carefully before using all.

[Reference](https://robots.thoughtbot.com/write-reliable-asynchronous-integration-tests-with-capybara)