### PR TITLE
Find content within a section

### DIFF
--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -17,12 +17,13 @@ module SitePrism
       Capybara.within(@root_element) { yield(self) } if block_given?
     end
 
-    def visible?
-      root_element.visible?
+    # Capybara::DSL module "delegates" Capybara methods to the "page" method
+    def page
+      root_element || Capybara.current_session
     end
 
-    def text
-      root_element.text
+    def visible?
+      page.visible?
     end
 
     def execute_script(input)
@@ -45,10 +46,6 @@ module SitePrism
 
     def find_first(*find_args)
       root_element.find(*find_args)
-    end
-
-    def find_all(*find_args)
-      root_element.all(*find_args)
     end
 
     def element_exists?(*find_args)

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -63,5 +63,29 @@ describe SitePrism::Section do
       expect(section).to respond_to(:execute_script)
       expect(section).to respond_to(:evaluate_script)
     end
+
+    it 'responds to #visible? method' do
+      expect(section).to respond_to(:visible?)
+    end
+
+    it 'responds to Capybara methods' do
+      expect(section).to respond_to(*Capybara::Session::DSL_METHODS)
+    end
+  end
+
+  describe 'page' do
+    subject(:section) { SitePrism::Section.new('parent', root_element).page }
+
+    let(:root_element) { 'root' }
+
+    it { is_expected.to eq('root') }
+
+    context 'when root element is nil' do
+      let(:root_element) { nil }
+
+      before { allow(Capybara).to receive(:current_session).and_return('current session') }
+
+      it { is_expected.to eq('current session') }
+    end
   end
 end


### PR DESCRIPTION
This PR related to issue #35 

If we write something like:
```ruby
expect(page.some_section).to have_content('Some content')
```
it will make capybara to look for this text on an entire page. But I think, many developers expect that `#have_content` method will search only in section.

Example, based on `TestHomePage` class:

**HTML**:
```html
...
<p>
  <a href='search.htm'>Search Page</a>
</p>
<article class='people'>
  <h1>People</h1>
  <span class='person'>person 1</span>
  <span class='person'>person 2</span>
  <span class='person'>person 3</span>
  <span class='person'>person 4</span>
</article>
...
```

**Code**:
```ruby
class TestHomePage < SitePrism::Page
  set_url '/home.htm'
  set_url_matcher(/home\.htm$/)
  ...
  section :people, People, '.people'
  ...
end
```

**Spec**:
```ruby
home = TestHomePage.new
home.load

expect(home.people).to have_content('Search Page')
```

Before my changes this spec finished without any failures, but now any capybara matchers scoped by section.