### PR TITLE
Lambda support inside page objects and sections

### DIFF
--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -4,6 +4,7 @@ require 'addressable/template'
 module SitePrism
   autoload :ElementContainer, 'site_prism/element_container'
   autoload :ElementChecker, 'site_prism/element_checker'
+  autoload :LambdaResolver, 'site_prism/lambda_resolver'
   autoload :Page, 'site_prism/page'
   autoload :Section, 'site_prism/section'
   autoload :Waiter, 'site_prism/waiter'

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -8,6 +8,7 @@ module SitePrism
   autoload :Page, 'site_prism/page'
   autoload :Section, 'site_prism/section'
   autoload :Waiter, 'site_prism/waiter'
+  autoload :AddressableQueryProcessor, 'site_prism/addressable_query_processor'
   autoload :AddressableUrlMatcher, 'site_prism/addressable_url_matcher'
 
   class << self

--- a/lib/site_prism/addressable_query_processor.rb
+++ b/lib/site_prism/addressable_query_processor.rb
@@ -1,0 +1,12 @@
+module SitePrism
+  class AddressableQueryProcessor
+    def self.restore(name, value)
+      return value.inject({}) { |h, (k, v)| h[k] = v.gsub(/\+/, ' ') ; h } if name == 'query'
+      return value
+    end
+
+    def self.match(_name)
+      return '.*'
+    end
+  end
+end

--- a/lib/site_prism/addressable_url_matcher.rb
+++ b/lib/site_prism/addressable_url_matcher.rb
@@ -84,7 +84,8 @@ module SitePrism
         unless (extracted_mappings = component_template.extract(component_url))
           # to support Addressable's expansion of queries, ensure it's parsing the fragment as appropriate (e.g. {?params*})
           prefix = COMPONENT_PREFIXES[component]
-          return nil unless prefix && (extracted_mappings = component_template.extract(prefix + component_url))
+          processor = component == :query ? AddressableQueryProcessor : nil
+          return nil unless prefix && (extracted_mappings = component_template.extract(prefix + component_url, processor))
         end
       end
       extracted_mappings

--- a/lib/site_prism/lambda_resolver.rb
+++ b/lib/site_prism/lambda_resolver.rb
@@ -1,0 +1,11 @@
+module SitePrism
+  module LambdaResolver
+    def resolve_lambdas(args)
+      args.map { |arg| resolve_lambda(arg) }
+    end
+
+    def resolve_lambda(arg)
+      arg.is_a?(Proc) ? instance_exec(&arg) : arg
+    end
+  end
+end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -5,6 +5,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
+    include LambdaResolver
     extend ElementContainer
 
     load_validation do
@@ -64,7 +65,7 @@ module SitePrism
     end
 
     def self.set_url(page_url)
-      @url = page_url.to_s
+      @url = page_url
     end
 
     def self.set_url_matcher(page_url_matcher)
@@ -81,11 +82,11 @@ module SitePrism
 
     def url(expansion = {})
       return nil if self.class.url.nil?
-      Addressable::Template.new(self.class.url).expand(expansion).to_s
+      Addressable::Template.new(resolve_lambda(self.class.url)).expand(expansion).to_s
     end
 
     def url_matcher
-      self.class.url_matcher
+      resolve_lambda(self.class.url_matcher)
     end
 
     def secure?
@@ -95,19 +96,19 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      page.find(*find_args)
+      page.find(*resolve_lambdas(find_args))
     end
 
     def find_all(*find_args)
-      page.all(*find_args)
+      page.all(*resolve_lambdas(find_args))
     end
 
     def element_exists?(*find_args)
-      page.has_selector?(*find_args)
+      page.has_selector?(*resolve_lambdas(find_args))
     end
 
     def element_does_not_exist?(*find_args)
-      page.has_no_selector?(*find_args)
+      page.has_no_selector?(*resolve_lambdas(find_args))
     end
 
     def url_matches?(expected_mappings = {})

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -5,6 +5,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
+    include LambdaResolver
     extend ElementContainer
 
     attr_reader :root_element, :parent
@@ -42,19 +43,19 @@ module SitePrism
     private
 
     def find_first(*find_args)
-      root_element.find(*find_args)
+      root_element.find(*resolve_lambdas(find_args))
     end
 
     def find_all(*find_args)
-      root_element.all(*find_args)
+      root_element.all(*resolve_lambdas(find_args))
     end
 
     def element_exists?(*find_args)
-      root_element.has_selector?(*find_args) unless root_element.nil?
+      root_element.has_selector?(*resolve_lambdas(find_args)) unless root_element.nil?
     end
 
     def element_does_not_exist?(*find_args)
-      root_element.has_no_selector?(*find_args) unless root_element.nil?
+      root_element.has_no_selector?(*resolve_lambdas(find_args)) unless root_element.nil?
     end
   end
 end

--- a/spec/addressable_url_matcher_spec.rb
+++ b/spec/addressable_url_matcher_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe SitePrism::AddressableUrlMatcher do
   describe '#matches?' do
-    let(:url) { 'https://joe:bleep@bazzle.com:8443/foos/22/bars/12?junk=janky#middle' }
+    let(:url) { 'https://joe:bleep@bazzle.com:8443/foos/22/bars/12?junk=janky&param=some+value#middle' }
 
     it 'matches on templated scheme' do
       expect_matches('{scheme}://bazzle.com').to eq true
@@ -80,7 +80,7 @@ describe SitePrism::AddressableUrlMatcher do
     end
 
     it 'matches on static query' do
-      expect_matches('/foos/22/bars/12?junk=janky').to eq true
+      expect_matches('/foos/22/bars/12?junk=janky&param=some+value').to eq true
     end
 
     it 'fails on bad query' do

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -76,4 +76,14 @@ describe SitePrism::Page do
     page = PageWithAFewElements.new
     expect(page).to respond_to :all_there?
   end
+
+  it 'should evaluate lambda selector' do
+    class PageWithLambdaElement < SitePrism::Page
+      element :element, -> { send(:lazy_query) }
+    end
+    page_with_lambda_element = PageWithLambdaElement.new
+    expect(page_with_lambda_element).to receive(:lazy_query).and_return('.element')
+    expect(Capybara.page).to receive(:find).with('.element')
+    page_with_lambda_element.element
+  end
 end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -54,6 +54,19 @@ describe SitePrism::Page do
         expect { Page.section :incorrect_section, '.section' }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
       end
     end
+
+    context 'second argument is a lambda' do
+      class PageWithLambdaSection < SitePrism::Page
+        section :section, SitePrism::Section, -> { send(:lazy_query) }
+      end
+
+      it 'should evaluate lambda query' do
+        page_with_lambda_section = PageWithLambdaSection.new
+        expect(page_with_lambda_section).to receive(:lazy_query).and_return('.section')
+        expect(Capybara.page).to receive(:find).with('.section')
+        page_with_lambda_section.section
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Allows using lambdas for arguments of `set_url`,  `set_url_matcher`,  `element`,  `elements`,  `section`,  `sections` methods. This allows to defer the evaluation of argument value until the value is actually needed (now it is always done at the moment classes are loaded).

This allows to reuse the same page class if DOM / URL is different based on some conditions (while keeping the same interface).
Use case:
```
class SomePage < SitePrism::Page
  element :some_element, -> { Someclass.some_property == some_val ? '#id1' : '#id2' }
end

# where Someclass.some_property is changed in a runtime
```