### PR TITLE
Add a method for using within with an already existing section

### DIFF
--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -9,10 +9,10 @@ module SitePrism
 
     attr_reader :root_element, :parent
 
-    def initialize(parent, root_element)
+    def initialize(parent, root_element, &block)
       @parent = parent
       @root_element = root_element
-      within { yield(self) } if block_given?
+      within(&block) if block_given?
     end
 
     def visible?

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -12,7 +12,7 @@ module SitePrism
     def initialize(parent, root_element)
       @parent = parent
       @root_element = root_element
-      Capybara.within(@root_element) { yield(self) } if block_given?
+      within { yield(self) } if block_given?
     end
 
     def visible?
@@ -37,6 +37,10 @@ module SitePrism
         candidate_page = candidate_page.parent
       end
       candidate_page
+    end
+
+    def within
+      Capybara.within(@root_element) { yield(self) }
     end
 
     private

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -70,7 +70,7 @@ describe SitePrism::Section do
 
   it 'passes a given block to #within' do
     block_variable = 5
-    expect_any_instance_of(SitePrism::Section).to receive(:within).and_yield
+    expect_any_instance_of(Capybara).to receive(:within).and_yield
     SitePrism::Section.new(a_page, 'div') { block_variable = 7 }
     expect(block_variable).to eq(7)
   end
@@ -88,16 +88,7 @@ describe SitePrism::Section do
       expect(section).to respond_to :evaluate_script
     end
 
-    it 'responds to within method' do
-      expect(section).to respond_to :within
-    end
-
     describe '#within' do
-      it 'passes a given block to Capybara.within' do
-        expect(Capybara).to receive(:within).with('locator')
-        section.within { 1 + 1 }
-      end
-
       it 'executes the block' do
         block_variable = 5
         expect(Capybara).to receive(:within).with('locator').and_yield

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -68,9 +68,11 @@ describe SitePrism::Section do
     expect(SitePrism::Section).to respond_to :elements
   end
 
-  it 'passes a given block to Capybara.within' do
-    expect(Capybara).to receive(:within).with('div')
-    SitePrism::Section.new(a_page, 'div') { 1 + 1 }
+  it 'passes a given block to #within' do
+    block_variable = 5
+    expect_any_instance_of(SitePrism::Section).to receive(:within).and_yield
+    SitePrism::Section.new(a_page, 'div') { block_variable = 7 }
+    expect(block_variable).to eq(7)
   end
 
   it 'does not require a block' do
@@ -84,6 +86,24 @@ describe SitePrism::Section do
     it 'responds to javascript methods' do
       expect(section).to respond_to :execute_script
       expect(section).to respond_to :evaluate_script
+    end
+
+    it 'responds to within method' do
+      expect(section).to respond_to :within
+    end
+
+    describe '#within' do
+      it 'passes a given block to Capybara.within' do
+        expect(Capybara).to receive(:within).with('locator')
+        section.within { 1 + 1 }
+      end
+
+      it 'executes the block' do
+        block_variable = 5
+        expect(Capybara).to receive(:within).with('locator').and_yield
+        section.within { block_variable = 7 }
+        expect(block_variable).to eq(7)
+      end
     end
   end
 end


### PR DESCRIPTION
We use a lot of ```sections``` in our site_prism code, and I was trying to use the ```within``` functionality to scope some expectations to a specific row in a table. Unfortunately, since the sections are initialized and placed into an array when using something like ```page.rows(text: "value").first``` it's not possible to add a block and execute code within the scope of the section. This change should leave the original behavior in place, and also add a method that allows users to scope a block for a ```section``` created by a ```sections``` declaration.