### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+dist: trusty
+
 rvm:
   - 2.3.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ before_install:
   - gem install bundler
 
 before_script:
-  - export DISPLAY=:99.0
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver*.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
 script:


### PR DESCRIPTION
Add settings for to install geckodriver on TravisCI.
- https://github.com/mozilla/geckodriver/releases
- SeleniumHQ/selenium#3236

Add `dist: trusty`
- Build : https://travis-ci.org/natritmeyer/site_prism/jobs/269819774
  - `This job ran on our Precise environment, which is in the process of being decommissioned. `
  - `Please read about the rollout of Trusty as default on the blog, and take note that you can explicitly stay on Precise by specifying dist: precise in your .travis.yml. `
- https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default