### PR TITLE
Dev Update 3 of 3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Encoding:
   EnforcedStyle: when_needed
 
 LineLength:
-  Max: 180
+  Max: 160
 
 MethodLength:
   Max: 11

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'selenium-webdriver'
 group :development do
   gem 'redcarpet'
   gem 'rubocop'
+  gem 'rspec'
   gem 'simplecov', require: false
   gem 'yard'
 end

--- a/TODO
+++ b/TODO
@@ -2,3 +2,5 @@ SitePrism::Page#wait_until_displayed
 anonymous sections
 Capybara 2.1 compatibility
   - iframe stuff
+
+Task for someone: Figure out why the loadable spec isn't playing nicely. One line to tidy up for full codecoverage compliance

--- a/config.reek
+++ b/config.reek
@@ -1,2 +1,0 @@
-IrresponsibleModule:
-  enabled: false

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -43,13 +43,6 @@ Then(/^that section is there too$/) do
   expect(@test_site.page_with_people.people_list).to have_headline text: 'People'
 end
 
-Then(/^I can see a section within a section$/) do
-  expect(@test_site.section_experiments).to have_parent_section
-  expect(@test_site.section_experiments.parent_section).to have_child_section
-  expect(@test_site.section_experiments.parent_section.child_section.nice_label.text).to eq 'something'
-  expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label text: 'something'
-end
-
 Then(/^I can see a section within a section using nested blocks$/) do
   expect(@test_site.section_experiments).to have_parent_section
   @test_site.section_experiments.parent_section do |parent|

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'
   s.add_dependency 'capybara', ['>= 2.1', '< 3.0']
-  s.add_dependency 'addressable', ['>=2.3.3', '< 3.0']
+  s.add_dependency 'addressable', ['~> 2.4']
 
-  s.add_development_dependency 'rspec', '< 4.0'
+  s.add_development_dependency 'rspec', ['~> 3.0']
 end

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -5,10 +5,6 @@ describe SitePrism::Loadable do
   let(:loadable) do
     Class.new do
       include SitePrism::Loadable
-
-      def foo
-        :foo
-      end
     end
   end
 
@@ -39,7 +35,7 @@ describe SitePrism::Loadable do
 
   describe '#when_loaded' do
     it 'raises if no block given' do
-      expect { loadable.new.when_loaded }.to raise_error ArgumentError
+      expect { loadable.new.when_loaded }.to raise_error(ArgumentError)
     end
 
     it 'executes and yields itself to the provided block when all load validations pass' do
@@ -48,9 +44,7 @@ describe SitePrism::Loadable do
 
       expect(instance).to receive(:foo)
 
-      instance.when_loaded do |l|
-        l.foo && true
-      end
+      instance.when_loaded { |l| l.foo }
     end
 
     it 'raises an exception if any load validation fails' do
@@ -70,7 +64,7 @@ describe SitePrism::Loadable do
       loadable.load_validation { [false, 'all your base are belong to us'] }
 
       expect do
-        loadable.new.when_loaded { puts 'foo' }
+        loadable.new.when_loaded { :foo }
       end.to raise_error(SitePrism::NotLoadedError, /all your base are belong to us/)
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -324,25 +324,19 @@ describe SitePrism::Page do
 
   it 'should raise an exception if passing a block to an element' do
     expect do
-      TestHomePage.new.invisible_element do
-        puts 'bla'
-      end
+      TestHomePage.new.invisible_element { :any_old_block }
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   it 'should raise an exception if passing a block to elements' do
     expect do
-      TestHomePage.new.lots_of_links do
-        puts 'bla'
-      end
+      TestHomePage.new.lots_of_links { :any_old_block }
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 
   it 'should raise an exception if passing a block to sections' do
     expect do
-      TestHomePage.new.nonexistent_section do
-        puts 'bla'
-      end
+      TestHomePage.new.nonexistent_section { :any_old_block }
     end.to raise_error(SitePrism::UnsupportedBlock)
   end
 


### PR DESCRIPTION
Much smaller and easier to digest (But not necessarily required straight away)
EDIT: Will land this in 2.9.1 so other branches from this won't conflict.

- Clean up some specs that weren't being used - Making code coverage almost pass 100% (1 line still in play)
- Update gemspec to be more semantic, as well as removing the permittance of RSpec `2.x` - No one developing should be using this, and it's just good to give things a spring clean
- Removed a few things no longer used (Step code / Reek configs)