### PR TITLE
Updated dependencies to 2015+ standards (2+ year refresh)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,11 @@
 To Update:
 1) Capybara 2.1+ compatibility - iFrame stuff
 (Need to update `Capybara` restrictions to something less old!)
-
-_This needs updating to at least 2.6+_ (Inline with last cut of SP development)
-
 2) Generic Update of dependencies
 3) Documentation of supported rubies
 4) Fix up of Gemfile and Gemspec to be inline with community guidelines
 See: http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
+5) Update of Ruby Version to supported version
 
 To Re-Triage:
 1) `SitePrism::Page#wait_until_displayed`
@@ -16,3 +14,7 @@ To Re-Triage:
 To be worked on now:
 1) Figure out why the loadable spec isn't playing nicely with code-coverage
 One line to tidy up for full compliance: `spec/page_spec.rb:91`
+2) Travis:
+- Add in multiple rubies
+- Add in Chrome
+- Update Driver/Browser

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -5,7 +5,7 @@ require './lib/site_prism/version'
 Gem::Specification.new do |s|
   s.name        = 'site_prism'
   s.version     = SitePrism::VERSION
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0'
   s.platform    = Gem::Platform::RUBY
   s.license     = 'BSD3'
   s.author      = 'Nat Ritmeyer'

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']
-  s.add_dependency 'capybara', ['>= 2.1', '< 3.0']
+  s.add_dependency 'capybara', ['~> 2.3']
 
-  s.add_development_dependency 'rspec', ['~> 3.0']
+  s.add_development_dependency 'rspec', ['~> 3.2']
 end


### PR DESCRIPTION
Branched from previous work now merged in.

2.10 refresh of dependencies. Only permit items 3 years or less old.