### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 # See full list of defaults here: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 # To see all cops used see here: https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
 
+AllCops:
+  TargetRubyVersion: 2.0
+
 Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'selenium-webdriver', '~> 3.4.0'
 
 group :development do
   gem 'redcarpet'
-  gem 'rubocop'
+  gem 'rubocop', '0.50.0'
   gem 'rspec'
   gem 'simplecov', require: false
   gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'selenium-webdriver', '~> 3.4.0'
 
 group :development do
   gem 'redcarpet'
-  gem 'rubocop', '0.50.0'
   gem 'rspec'
+  gem 'rubocop', '0.50.0'
   gem 'simplecov', require: false
   gem 'yard'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -27,4 +27,4 @@ namespace :docs do
   end
 end
 
-task default: %w(spec:all cuke:all)
+task default: %w[spec:all cuke:all]

--- a/Rakefile
+++ b/Rakefile
@@ -27,4 +27,4 @@ namespace :docs do
   end
 end
 
-task default: %w[spec:all cuke:all]
+task default: %w[rubocop spec:all cuke:all]

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -113,7 +113,7 @@ end
 Then(/^I can see individual people in the people list$/) do
   expect(@test_site.home.people.individuals.size).to eq(4)
   expect(@test_site.home.people.individuals(count: 4).size).to eq(4)
-  expect(@test_site.home.people).to have_individuals count: 4
+  expect(@test_site.home.people).to have_individuals(count: 4)
 end
 
 Then(/^I can get access to a page through a section$/) do

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -113,7 +113,7 @@ end
 Then(/^I can see individual people in the people list$/) do
   expect(@test_site.home.people.individuals.size).to eq(4)
   expect(@test_site.home.people.individuals(count: 4).size).to eq(4)
-  expect(@test_site.home.people).to have_individuals count:(4)
+  expect(@test_site.home.people).to have_individuals count: 4
 end
 
 Then(/^I can get access to a page through a section$/) do

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -46,7 +46,7 @@ describe SitePrism::Loadable do
 
       expect(instance).to receive(:foo)
 
-      instance.when_loaded { |l| l.foo }
+      instance.when_loaded(&:foo)
     end
 
     it 'raises an exception if any load validation fails' do

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -53,7 +53,9 @@ describe SitePrism::Page do
       it 'should raise an ArgumentError' do
         class Page < SitePrism::Page
         end
-        expect { Page.section :incorrect_section, '.section' }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
+        expect do
+          Page.section :incorrect_section, '.section'
+        end.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
       end
     end
   end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -50,12 +50,12 @@ describe SitePrism::Page do
     end
 
     context 'second argument is not a class and no block given' do
+      subject(:section) { Page.section(:incorrect_section, '.section') }
+
       it 'should raise an ArgumentError' do
         class Page < SitePrism::Page
         end
-        expect do
-          Page.section :incorrect_section, '.section'
-        end.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
+        expect { section }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
       end
     end
   end


### PR DESCRIPTION
Hi @luke-hill 
Thank you for answering [my question](https://github.com/natritmeyer/site_prism/pull/199#issuecomment-367259959).
I solved the identification by rubocop.

## Change Point
#### 1. Fixed version of rubocop with '0.50.0
I fixed version of rubocop with '0.50.0', because the Ruby version specified in 'site_prism.gemspec' and the supported by latest rubocop did not match.
It caused the following points to be pointed out.

```
site_prism.gemspec:8:29: C: Gemspec/RequiredRubyVersion: required_ruby_version (2.0, declared in site_prism.gemspec) 
  and TargetRubyVersion (2.1, declared in .rubocop.yml) should be equal.
  s.required_ruby_version = '>= 2.0'
```

Although I thought of several countermeasures,I fixed it as fixed version by referring to the following issue.
Reference issue : https://github.com/bbatsov/rubocop/issues/5260#issuecomment-352151774

#### 2. Fixed identification by rubocop
- Improved with 'bundle exec rubocop -a'.
- Easy fix by manual work.
- Explicitly specify Ruby version in .rubocop.yml.

#### 3. Added setting in Rakefile
The setting was deleted by [this PullRequest](https://github.com/natritmeyer/site_prism/pull/199) but it was added because the rubocop test was restored.
If you prefer not to change, I revert the commit.