### PR TITLE
Gemfile -> Gemspec migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'cucumber', '~> 2.4.0'
-gem 'rake'
-gem 'selenium-webdriver', '~> 3.4.0'
-
-group :development do
-  gem 'redcarpet'
-  gem 'rspec'
-  gem 'rubocop', '0.50.0'
-  gem 'simplecov', require: false
-  gem 'yard'
-end

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,8 @@
 To Update:
 1) (Need to update `Capybara` restrictions to something less old!)
-2) Generic Update of other dependencies
-3) Fix up of Gemfile and Gemspec to be inline with community guidelines
-See: http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
-4) Update to Rubies (Support & Documentation)
+2) Generic Update of dependencies
+3) Documentation of supported rubies
+4) Update of Ruby Version to supported version
 
 Next Up:
 1) Figure out why the loadable spec isn't playing nicely with code-coverage

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -18,5 +18,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable', ['~> 2.4']
   s.add_dependency 'capybara', ['~> 2.3']
 
+  s.add_development_dependency 'cucumber', ['2.4.0']
+  s.add_development_dependency 'rake', ['~> 11.0']
+  s.add_development_dependency 'redcarpet', ['~> 3.0']
   s.add_development_dependency 'rspec', ['~> 3.2']
+  s.add_development_dependency 'rubocop', ['0.50.0']
+  s.add_development_dependency 'selenium-webdriver', ['~> 3.4.0']
+  s.add_development_dependency 'simplecov', ['~> 0.10']
+  s.add_development_dependency 'yard', ['~> 0.8']
 end


### PR DESCRIPTION
Added low (2015 end), …versions where none specified.

This will conflict with #201 so will be merged in after it (Possibly in `2.11`, if not in `2.12`) - Dependent on other feature / refactor work and time between revisions (Want to keep it below a few weeks in between version bumps)

Bumps to the variety of dependencies which are either fixed or well below their best to come in future releases