### PR TITLE
Refactor element checks sans metaprogramming

### DIFF
--- a/features/step_definitions/iframe_steps.rb
+++ b/features/step_definitions/iframe_steps.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 Then(/^I can locate the iframe by id$/) do
-  @test_site.home.wait_for_my_iframe
+  @test_site.home.wait_for(:my_iframe)
 
-  expect(@test_site.home).to have_my_iframe
+  expect(@test_site.home.has?(:my_iframe)).to be true
 end
 
 Then(/^I can locate the iframe by index$/) do
-  @test_site.home.wait_for_index_iframe
+  @test_site.home.wait_for(:index_iframe)
 
-  expect(@test_site.home).to have_index_iframe
+  expect(@test_site.home.has?(:index_iframe)).to be true
 end
 
 Then(/^I can see elements in an iframe$/) do
@@ -20,6 +20,6 @@ end
 
 Then(/^I can see elements in an iframe with capybara query options$/) do
   @test_site.home.my_iframe do |f|
-    expect(f).to have_some_text(text: 'Some text in an iframe')
+    expect(f.has?(:some_text, text: 'Some text in an iframe')).to be true
   end
 end

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -9,15 +9,15 @@ Then(/^the page has no title$/) do
 end
 
 Then(/^the page does not have element$/) do
-  expect(@test_site.home.has_no?(:nonexistent_element)).to be true
+  expect(@test_site.home.no?(:nonexistent_element)).to be true
 
-  expect { @test_site.home.has_no?(:nonexistent_element) }.not_to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.home.no?(:nonexistent_element) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^the page does not have elements$/) do
-  expect(@test_site.home.has_no?(:nonexistent_elements)).to be true
+  expect(@test_site.home.no?(:nonexistent_elements)).to be true
 
-  expect { @test_site.home.has_no?(:nonexistent_elements) }.not_to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.home.no?(:nonexistent_elements) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^I can see the welcome header$/) do
@@ -33,7 +33,7 @@ Then(/^I can see the welcome header with capybara query options$/) do
 end
 
 Then(/^the welcome header is not matched with invalid text$/) do
-  expect(@test_site.home.has_no?(:welcome_header, text: "This Doesn't Match!")).to be true
+  expect(@test_site.home.no?(:welcome_header, text: "This Doesn't Match!")).to be true
 end
 
 Then(/^I can see the welcome message$/) do
@@ -59,13 +59,13 @@ end
 
 Then(/^I cannot see the missing squirrel$/) do
   using_wait_time(0) do
-    expect(@test_site.home.has_no?(:squirrel)).to be true
+    expect(@test_site.home.no?(:squirrel)).to be true
   end
 end
 
 Then(/^I cannot see the missing other thingy$/) do
   using_wait_time(0) do
-    expect(@test_site.home.has_no?(:other_thingy)).to be true
+    expect(@test_site.home.no?(:other_thingy)).to be true
   end
 end
 

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -9,68 +9,68 @@ Then(/^the page has no title$/) do
 end
 
 Then(/^the page does not have element$/) do
-  expect(@test_site.home.has_no_nonexistent_element?).to be true
+  expect(@test_site.home.has_no?(:nonexistent_element)).to be true
 
-  expect(@test_site.home).to have_no_nonexistent_element
+  expect { @test_site.home.has_no?(:nonexistent_element) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^the page does not have elements$/) do
-  expect(@test_site.home.has_no_nonexistent_elements?).to be true
+  expect(@test_site.home.has_no?(:nonexistent_elements)).to be true
 
-  expect(@test_site.home).to have_no_nonexistent_elements
+  expect { @test_site.home.has_no?(:nonexistent_elements) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^I can see the welcome header$/) do
-  expect(@test_site.home).to have_welcome_header
+  expect(@test_site.home.has?(:welcome_header)).to be true
 
   expect(@test_site.home.welcome_header.text).to eq('Welcome')
 end
 
 Then(/^I can see the welcome header with capybara query options$/) do
-  expect(@test_site.home).to have_welcome_header(text: 'Welcome')
+  expect(@test_site.home.has?(:welcome_header, text: 'Welcome')).to be true
 
   expect { @test_site.home.welcome_header text: 'Welcome' }.not_to raise_error
 end
 
 Then(/^the welcome header is not matched with invalid text$/) do
-  expect(@test_site.home).to have_no_welcome_header(text: "This Doesn't Match!")
+  expect(@test_site.home.has_no?(:welcome_header, text: "This Doesn't Match!")).to be true
 end
 
 Then(/^I can see the welcome message$/) do
-  expect(@test_site.home).to have_welcome_message
+  expect(@test_site.home.has?(:welcome_message)).to be true
 
   expect(@test_site.home.welcome_message.text).to eq('This is the home page, there is some stuff on it')
 end
 
 Then(/^I can see the welcome message with capybara query options$/) do
-  expect(@test_site.home).to have_welcome_message(text: 'This is the home page, there is some stuff on it')
+  expect(@test_site.home.has?(:welcome_message, text: 'This is the home page, there is some stuff on it')).to be true
 end
 
 Then(/^I can see the go button$/) do
-  expect(@test_site.home).to have_go_button
+  expect(@test_site.home.has?(:go_button)).to be true
   @test_site.home.go_button.click
 end
 
 Then(/^I can see the link to the search page$/) do
-  expect(@test_site.home).to have_link_to_search_page
+  expect(@test_site.home.has?(:link_to_search_page)).to be true
 
   expect(@test_site.home.link_to_search_page['href']).to include('search.htm')
 end
 
 Then(/^I cannot see the missing squirrel$/) do
   using_wait_time(0) do
-    expect(@test_site.home).not_to have_squirrel
+    expect(@test_site.home.has_no?(:squirrel)).to be true
   end
 end
 
 Then(/^I cannot see the missing other thingy$/) do
   using_wait_time(0) do
-    expect(@test_site.home).not_to have_other_thingy
+    expect(@test_site.home.has_no?(:other_thingy)).to be true
   end
 end
 
 Then(/^I can see the group of links$/) do
-  expect(@test_site.home).to have_lots_of_links
+  expect(@test_site.home.has?(:lots_of_links)).to be true
 end
 
 Then(/^I can get the group of links$/) do
@@ -82,35 +82,35 @@ Then(/^all expected elements are present$/) do
 end
 
 Then(/^an exception is raised when I try to deal with an element with no selector$/) do
-  expect { @test_site.no_title.has_element_without_selector? }.to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.no_title.has?(:element_without_selector) }.to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.element_without_selector }.to raise_error(SitePrism::NoSelectorForElement)
-  expect { @test_site.no_title.wait_for_element_without_selector }.to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.no_title.wait_for(:element_without_selector) }.to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^an exception is raised when I try to deal with elements with no selector$/) do
-  expect { @test_site.no_title.has_elements_without_selector? }.to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.no_title.has?(:elements_without_selector) }.to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.elements_without_selector }.to raise_error(SitePrism::NoSelectorForElement)
-  expect { @test_site.no_title.wait_for_elements_without_selector }.to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.no_title.wait_for(:elements_without_selector) }.to raise_error(SitePrism::NoSelectorForElement)
 end
 
 When(/^I wait until a particular element is visible$/) do
-  @test_site.home.wait_until_some_slow_element_visible
+  @test_site.home.wait_until_visible(:some_slow_element)
 end
 
 When(/^I wait for a specific amount of time until a particular element is visible$/) do
-  @test_site.home.wait_until_shy_element_visible(5)
+  @test_site.home.wait_until_visible(:shy_element, 5)
 end
 
 Then(/^the previously invisible element is visible$/) do
-  expect(@test_site.home).to have_shy_element
+  expect(@test_site.home.has?(:shy_element)).to be true
 end
 
 Then(/^I get a timeout error when I wait for an element that never appears$/) do
-  expect { @test_site.home.wait_until_invisible_element_visible(1) }.to raise_error(SitePrism::TimeOutWaitingForElementVisibility)
+  expect { @test_site.home.wait_until_visible(:invisible_element, 1) }.to raise_error(SitePrism::TimeOutWaitingForElementVisibility)
 end
 
 When(/^I wait while for an element to become invisible$/) do
-  @test_site.home.wait_until_retiring_element_invisible
+  @test_site.home.wait_until_invisible(:retiring_element)
 end
 
 Then(/^the previously visible element is invisible$/) do
@@ -118,16 +118,16 @@ Then(/^the previously visible element is invisible$/) do
 end
 
 When(/^I wait for a specific amount of time until a particular element is invisible$/) do
-  @test_site.home.wait_until_retiring_element_invisible(5)
+  @test_site.home.wait_until_invisible(:retiring_element, 5)
 end
 
 Then(/^I get a timeout error when I wait for an element that never disappears$/) do
-  expect { @test_site.home.wait_until_welcome_header_invisible(1) }.to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
+  expect { @test_site.home.wait_until_invisible(:welcome_header, 1) }.to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
 end
 
 Then(/^I do not wait for an nonexistent element when checking for invisibility$/) do
   start = Time.new
-  @test_site.home.wait_until_nonexistent_element_invisible(10)
+  @test_site.home.wait_until_invisible(:nonexistent_element, 10)
 
   expect(Time.new - start).to be < 1
 end
@@ -137,18 +137,18 @@ When(/^I wait for invisibility of an element embedded into a section which is re
 end
 
 Then(/^I receive an error when a section with the element I am waiting for is removed$/) do
-  expect { @test_site.home.container_with_element.wait_until_embedded_element_invisible }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.container_with_element.wait_until_invisible(:embedded_element) }.to raise_error(Capybara::ElementNotFound)
 end
 
 Then(/^I can wait a variable time for elements to appear$/) do
-  @test_site.home.wait_for_lots_of_links
-  @test_site.home.wait_for_lots_of_links(0.1)
+  @test_site.home.wait_for(:lots_of_links)
+  @test_site.home.wait_for(:lots_of_links, 0.1)
 end
 
 Then(/^I can wait a variable time and pass specific parameters$/) do
-  @test_site.home.wait_for_lots_of_links(0.1, count: 2)
+  @test_site.home.wait_for(:lots_of_links, 0.1, count: 2)
   Capybara.using_wait_time 0.3 do
     # intentionally wait and pass nil to force this to cycle
-    expect(@test_site.home.wait_for_lots_of_links(nil, count: 198_108_14)).to be false
+    expect(@test_site.home.wait_for(:lots_of_links, nil, count: 198_108_14)).to be false
   end
 end

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 Then(/^I can see elements in the section$/) do
-  expect(@test_site.home).to have_people
+  expect(@test_site.home.has?(:people)).to be true
   expect(@test_site.home.people.headline).to have_content('People')
-  expect(@test_site.home.people).to have_headline(text: 'People')
+  expect(@test_site.home.people.has?(:headline, text: 'People')).to be true
 end
 
 Then(/^I can see a section in a section$/) do
-  expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label(text: 'something')
+  expect(@test_site.section_experiments.parent_section.child_section.has?(:nice_label, text: 'something')).to be true
 end
 
 Then(/^I can access elements within the section using a block$/) do
-  expect(@test_site.home).to have_people
+  expect(@test_site.home.has?(:people)).to be true
 
   @test_site.home.people do |persons|
-    expect(persons).to have_headline(text: 'People')
+    expect(persons.has?(:headline, text: 'People')).to be true
     expect(persons.headline.text).to eq('People')
-    expect(persons).to have_no_dinosaur
-    expect(persons).to have_individuals(count: 4)
+    expect(persons.has_no?(:dinosaur)).to be true
+    expect(persons.has?(:individuals, count: 4)).to be true
   end
 
   # the above would pass if the block were ignored, this verifies it is executed:
   expect do
-    @test_site.home.people { |p| expect(p).to have_dinosaur }
+    @test_site.home.people { |p| expect(p.has?(:dinosaur)).to be true }
   end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 
@@ -31,37 +31,37 @@ Then(/^access to elements is constrained to those within the section$/) do
 
   @test_site.home.people do |persons|
     expect(persons).to have_no_css('.welcome')
-    expect { persons.has_welcome_message? }.to raise_error(NoMethodError)
-    expect(persons).to have_no_welcome_message_on_the_parent
+    expect { persons.has(:welcome_message) }.to raise_error(NoMethodError)
+    expect(persons.has_no?(:welcome_message_on_the_parent)).to be true
   end
 end
 
 Then(/^the page does not have a section$/) do
-  expect(@test_site.home.has_no_nonexistent_section?).to be true
+  expect(@test_site.home.has_no?(:nonexistent_section)).to be true
 
-  expect(@test_site.home).to have_no_nonexistent_section
+  expect { @test_site.home.has_no?(:nonexistent_section) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^that section is there too$/) do
-  expect(@test_site.page_with_people).to have_people_list
+  expect(@test_site.page_with_people.has?(:people_list)).to be true
   expect(@test_site.page_with_people.people_list.headline).to have_content('People')
-  expect(@test_site.page_with_people.people_list).to have_headline(text: 'People')
+  expect(@test_site.page_with_people.people_list.has?(:headline, text: 'People')).to be true
 end
 
 Then(/^I can see a section within a section using nested blocks$/) do
-  expect(@test_site.section_experiments).to have_parent_section
+  expect(@test_site.section_experiments.has?(:parent_section)).to be true
 
   @test_site.section_experiments.parent_section do |parent|
-    expect(parent).to have_child_section
+    expect(parent.has?(:child_section)).to be true
     expect(parent.child_section.nice_label.text).to eq('something')
     parent.child_section do |child|
-      expect(child).to have_nice_label(text: 'something')
+      expect(child.has?(:nice_label, text: 'something')).to be true
     end
   end
 end
 
 Then(/^I can see a collection of sections$/) do
-  expect(@test_site.section_experiments).to have_search_results
+  expect(@test_site.section_experiments.has?(:search_results)).to be true
 
   @test_site.section_experiments.search_results.each_with_index do |search_result, i|
     expect(search_result.title.text).to eq("title #{i}")
@@ -74,13 +74,13 @@ Then(/^I can see a collection of sections$/) do
 end
 
 Then(/^I can see an anonymous section$/) do
-  expect(@test_site.section_experiments).to have_anonymous_section
+  expect(@test_site.section_experiments.has?(:anonymous_section)).to be true
   expect(@test_site.section_experiments.anonymous_section.title.text).to eq('Anonymous Section')
   expect(@test_site.section_experiments.anonymous_section.upcase_title_text).to eq('ANONYMOUS SECTION')
 end
 
 Then(/^I can see a collection of anonymous sections$/) do
-  expect(@test_site.section_experiments).to have_anonymous_section
+  expect(@test_site.section_experiments.has?(:anonymous_section)).to be true
 
   @test_site.section_experiments.anonymous_sections.each_with_index do |section, i|
     expect(section.title.text).to eq("Section #{i}")
@@ -113,7 +113,7 @@ end
 Then(/^I can see individual people in the people list$/) do
   expect(@test_site.home.people.individuals.size).to eq(4)
   expect(@test_site.home.people.individuals(count: 4).size).to eq(4)
-  expect(@test_site.home.people).to have_individuals(count: 4)
+  expect(@test_site.home.people.has?(:individuals, count: 4)).to be true
 end
 
 Then(/^I can get access to a page through a section$/) do
@@ -141,11 +141,11 @@ Then(/^I can get direct access to a page through a child section$/) do
 end
 
 Then(/^the page contains a section with no element$/) do
-  expect(@test_site.home.people).to have_no_dinosaur
+  expect(@test_site.home.has_no?(:dinosaur)).to be true
 end
 
 Then(/^the page contains a deeply nested span$/) do
-  expect(@test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0]).to have_deep_span
+  expect(@test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0].has?(:deep_span)).to be true
   expect(@test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0].deep_span.text).to eq 'Deep span'
 end
 

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -16,7 +16,7 @@ Then(/^I can access elements within the section using a block$/) do
   @test_site.home.people do |persons|
     expect(persons.has?(:headline, text: 'People')).to be true
     expect(persons.headline.text).to eq('People')
-    expect(persons.has_no?(:dinosaur)).to be true
+    expect(persons.no?(:dinosaur)).to be true
     expect(persons.has?(:individuals, count: 4)).to be true
   end
 
@@ -32,14 +32,14 @@ Then(/^access to elements is constrained to those within the section$/) do
   @test_site.home.people do |persons|
     expect(persons).to have_no_css('.welcome')
     expect { persons.has(:welcome_message) }.to raise_error(NoMethodError)
-    expect(persons.has_no?(:welcome_message_on_the_parent)).to be true
+    expect(persons.no?(:welcome_message_on_the_parent)).to be true
   end
 end
 
 Then(/^the page does not have a section$/) do
-  expect(@test_site.home.has_no?(:nonexistent_section)).to be true
+  expect(@test_site.home.no?(:nonexistent_section)).to be true
 
-  expect { @test_site.home.has_no?(:nonexistent_section) }.not_to raise_error(SitePrism::NoSelectorForElement)
+  expect { @test_site.home.no?(:nonexistent_section) }.not_to raise_error(SitePrism::NoSelectorForElement)
 end
 
 Then(/^that section is there too$/) do
@@ -141,7 +141,7 @@ Then(/^I can get direct access to a page through a child section$/) do
 end
 
 Then(/^the page contains a section with no element$/) do
-  expect(@test_site.home.has_no?(:dinosaur)).to be true
+  expect(@test_site.home.no?(:dinosaur)).to be true
 end
 
 Then(/^the page contains a deeply nested span$/) do

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 Then(/^when I wait for the element that takes a while to appear$/) do
-  @test_site.home.wait_for_some_slow_element
+  @test_site.home.wait_for(:some_slow_element)
 end
 
 Then(/^I successfully wait for it to appear$/) do
-  expect(@test_site.home).to have_some_slow_element
+  expect(@test_site.home.has?(:some_slow_element)).to be true
 end
 
 When(/^I wait for a specifically short amount of time for an element to appear$/) do
-  @test_site.home.wait_for_some_slow_element(2)
+  @test_site.home.wait_for(:some_slow_element, 2)
 end
 
 Then(/^the element I am waiting for doesn't appear in time$/) do
@@ -17,9 +17,9 @@ Then(/^the element I am waiting for doesn't appear in time$/) do
 end
 
 Then(/^when I wait for the section element that takes a while to appear$/) do
-  @test_site.section_experiments.parent_section.wait_for_slow_section_element
+  @test_site.section_experiments.parent_section.wait_for(:slow_section_element)
 end
 
 Then(/^I successfully wait for the slow section element to appear$/) do
-  expect(@test_site.section_experiments.parent_section).to have_slow_section_element
+  expect(@test_site.section_experiments.parent_section.has?(:slow_section_element)).to be true
 end

--- a/lib/site_prism/element_checker.rb
+++ b/lib/site_prism/element_checker.rb
@@ -3,7 +3,7 @@
 module SitePrism
   module ElementChecker
     def all_there?
-      self.class.mapped_items.all? { |element| send "has_#{element}?" }
+      self.class.mapped_items.each_key.all? { |element| has?(element) }
     end
   end
 end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -14,7 +14,7 @@ module SitePrism
       end
     end
 
-    def has_no?(element_name, *args)
+    def no?(element_name, *args)
       selector_for(element_name) { return true }
       !has?(element_name, *args)
     end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -2,185 +2,166 @@
 
 module SitePrism
   module ElementContainer
-    attr_reader :mapped_items
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
 
-    def element(element_name, *find_args)
-      build element_name, *find_args do
-        define_method element_name.to_s do |*runtime_args, &element_block|
-          self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-          find_first(*find_args, *runtime_args)
+    def has?(element_name, *args)
+      selector = selector_for(element_name) { raise_no_selector(element_name) }
+      wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
+      Capybara.using_wait_time wait_time do
+        element_exists?(*selector, *args)
+      end
+    end
+
+    def has_no?(element_name, *args)
+      selector_for(element_name) { return true }
+      !has?(element_name, *args)
+    end
+
+    def wait_for(element_name, timeout = nil, *args)
+      selector = selector_for(element_name) { raise_no_selector(element_name) }
+      timeout = timeout.nil? ? Waiter.default_wait_time : timeout
+      Capybara.using_wait_time timeout do
+        element_exists?(*selector, *args)
+      end
+    end
+
+    def wait_until_visible(element_name, timeout = Waiter.default_wait_time, *args)
+      selector = selector_for(element_name) { raise_no_selector(element_name) }
+      Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
+        Capybara.using_wait_time 0 do
+          sleep 0.05 until element_exists?(*selector, *args, visible: true)
         end
       end
     end
 
-    def elements(collection_name, *find_args)
-      build collection_name, *find_args do
-        define_method collection_name.to_s do |*runtime_args, &element_block|
-          self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args)
+    def wait_until_invisible(element_name, timeout = Waiter.default_wait_time, *args)
+      selector = selector_for(element_name) { raise_no_selector(element_name) }
+      Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
+        Capybara.using_wait_time 0 do
+          sleep 0.05 while element_exists?(*selector, *args, visible: true)
         end
       end
-    end
-    alias collection elements
-
-    def section(section_name, *args, &block)
-      section_class, find_args = extract_section_options args, &block
-      build section_name, *find_args do
-        define_method section_name do |*runtime_args, &runtime_block|
-          section_class.new self, find_first(*find_args, *runtime_args), &runtime_block
-        end
-      end
-    end
-
-    def sections(section_collection_name, *args, &block)
-      section_class, find_args = extract_section_options args, &block
-      build section_collection_name, *find_args do
-        define_method section_collection_name do |*runtime_args, &element_block|
-          self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
-          find_all(*find_args, *runtime_args).map do |element|
-            section_class.new self, element
-          end
-        end
-      end
-    end
-
-    def iframe(iframe_name, iframe_page_class, selector)
-      element_selector = deduce_iframe_element_selector(selector)
-      scope_selector = deduce_iframe_scope_selector(selector)
-      add_to_mapped_items iframe_name
-      create_existence_checker iframe_name, element_selector
-      create_nonexistence_checker iframe_name, element_selector
-      create_waiter iframe_name, element_selector
-      define_method iframe_name do |&block|
-        within_frame scope_selector do
-          block.call iframe_page_class.new
-        end
-      end
-    end
-
-    def add_to_mapped_items(item)
-      @mapped_items ||= []
-      @mapped_items << item.to_s
-    end
-
-    def raise_if_block(obj, name, has_block)
-      return unless has_block
-      raise SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
     end
 
     private
 
-    def build(name, *find_args)
-      if find_args.empty?
-        create_no_selector name
-      else
-        add_to_mapped_items name
-        yield
-      end
-      add_helper_methods name, *find_args
+    def selector_for(element_name)
+      selector = self.class.mapped_items[element_name.to_s] || []
+      yield if selector.empty?
+      selector
     end
 
-    def add_helper_methods(name, *find_args)
-      create_existence_checker name, *find_args
-      create_nonexistence_checker name, *find_args
-      create_waiter name, *find_args
-      create_visibility_waiter name, *find_args
-      create_invisibility_waiter name, *find_args
+    def fetch_element_find_args(name)
+      find_args = self.class.mapped_items.fetch(name.to_s, [])
+      raise_no_selector(name) if find_args.empty?
+      find_args
     end
 
-    def create_helper_method(proposed_method_name, *find_args)
-      if find_args.empty?
-        create_no_selector proposed_method_name
-      else
-        yield
-      end
+    def raise_no_selector(element_name)
+      raise SitePrism::NoSelectorForElement.new, "#{self.class.name} => :#{element_name} needs a selector"
     end
 
-    def create_existence_checker(element_name, *find_args)
-      method_name = "has_#{element_name}?"
-      create_helper_method method_name, *find_args do
-        define_method method_name do |*runtime_args|
-          wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
-          Capybara.using_wait_time wait_time do
-            element_exists?(*find_args, *runtime_args)
+    module ClassMethods
+      def element(element_name, *find_args)
+        build element_name, *find_args do
+          define_method element_name.to_s do |*runtime_args, &element_block|
+            self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
+            find_first(*find_args, *runtime_args)
           end
         end
       end
-    end
 
-    def create_nonexistence_checker(element_name, *find_args)
-      method_name = "has_no_#{element_name}?"
-      create_helper_method method_name, *find_args do
-        define_method method_name do |*runtime_args|
-          wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
-          Capybara.using_wait_time wait_time do
-            element_does_not_exist?(*find_args, *runtime_args)
+      def elements(collection_name, *find_args)
+        build collection_name, *find_args do
+          define_method collection_name.to_s do |*runtime_args, &element_block|
+            self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
+            find_all(*find_args, *runtime_args)
           end
         end
       end
-    end
+      alias collection elements
 
-    def create_waiter(element_name, *find_args)
-      method_name = "wait_for_#{element_name}"
-      create_helper_method method_name, *find_args do
-        define_method method_name do |timeout = nil, *runtime_args|
-          timeout = timeout.nil? ? Waiter.default_wait_time : timeout
-          Capybara.using_wait_time timeout do
-            element_exists?(*find_args, *runtime_args)
+      def section(section_name, *args, &block)
+        section_class, find_args = extract_section_options args, &block
+        build section_name, *find_args do
+          define_method section_name do |*runtime_args, &runtime_block|
+            section_class.new self, find_first(*find_args, *runtime_args), &runtime_block
           end
         end
       end
-    end
 
-    def create_visibility_waiter(element_name, *find_args)
-      method_name = "wait_until_#{element_name}_visible"
-      create_helper_method method_name, *find_args do
-        define_method method_name do |timeout = Waiter.default_wait_time, *runtime_args|
-          Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
-            Capybara.using_wait_time 0 do
-              sleep 0.05 until element_exists?(*find_args, *runtime_args, visible: true)
+      def sections(section_collection_name, *args, &block)
+        section_class, find_args = extract_section_options args, &block
+        build section_collection_name, *find_args do
+          define_method section_collection_name do |*runtime_args, &element_block|
+            self.class.raise_if_block(self, section_collection_name.to_s, !element_block.nil?)
+            find_all(*find_args, *runtime_args).map do |element|
+              section_class.new self, element
             end
           end
         end
       end
-    end
 
-    def create_invisibility_waiter(element_name, *find_args)
-      method_name = "wait_until_#{element_name}_invisible"
-      create_helper_method method_name, *find_args do
-        define_method method_name do |timeout = Waiter.default_wait_time, *runtime_args|
-          Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
-            Capybara.using_wait_time 0 do
-              sleep 0.05 while element_exists?(*find_args, *runtime_args, visible: true)
-            end
+      def iframe(iframe_name, iframe_page_class, selector)
+        element_selector = deduce_iframe_element_selector(selector)
+        scope_selector = deduce_iframe_scope_selector(selector)
+        mapped_items[iframe_name.to_s] = element_selector
+        define_method iframe_name do |&block|
+          within_frame scope_selector do
+            block.call iframe_page_class.new
           end
         end
       end
-    end
 
-    def create_no_selector(method_name)
-      define_method method_name do
-        raise SitePrism::NoSelectorForElement.new, "#{self.class.name} => :#{method_name} needs a selector"
+      def mapped_items
+        @mapped_items ||= {}
       end
-    end
 
-    def deduce_iframe_scope_selector(selector)
-      selector.is_a?(Integer) ? selector : selector.split('#').last
-    end
-
-    def deduce_iframe_element_selector(selector)
-      selector.is_a?(Integer) ? "iframe:nth-of-type(#{selector + 1})" : selector
-    end
-
-    def extract_section_options(args, &block)
-      if args.first.is_a?(Class)
-        section_class = args.shift
-      elsif block_given?
-        section_class = Class.new SitePrism::Section, &block
-      else
-        raise ArgumentError, 'You should provide section class either as a block, or as the second argument'
+      def raise_if_block(obj, name, has_block)
+        return unless has_block
+        raise SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
       end
-      return section_class, args
+
+      private
+
+      def build(name, *find_args)
+        if find_args.empty?
+          define_method(name) { raise_no_selector(name) }
+        else
+          mapped_items[name.to_s] = find_args
+          yield
+        end
+      end
+
+      def create_helper_method(proposed_method_name, *find_args)
+        if find_args.empty?
+          define_method(proposed_method_name) { raise_no_selector(proposed_method_name) }
+          create_no_selector proposed_method_name
+        else
+          yield
+        end
+      end
+
+      def deduce_iframe_scope_selector(selector)
+        selector.is_a?(Integer) ? selector : selector.split('#').last
+      end
+
+      def deduce_iframe_element_selector(selector)
+        selector.is_a?(Integer) ? "iframe:nth-of-type(#{selector + 1})" : selector
+      end
+
+      def extract_section_options(args, &block)
+        if args.first.is_a?(Class)
+          section_class = args.shift
+        elsif block_given?
+          section_class = Class.new SitePrism::Section, &block
+        else
+          raise ArgumentError, 'You should provide section class either as a block, or as the second argument'
+        end
+        return section_class, args
+      end
     end
   end
 end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -7,7 +7,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
-    extend ElementContainer
+    include ElementContainer
 
     load_validation do
       [displayed?, "Expected #{current_url} to match #{url_matcher} but it did not."]
@@ -106,10 +106,6 @@ module SitePrism
 
     def element_exists?(*find_args)
       page.has_selector?(*find_args)
-    end
-
-    def element_does_not_exist?(*find_args)
-      page.has_no_selector?(*find_args)
     end
 
     def url_matches?(expected_mappings = {})

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -7,7 +7,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
-    extend ElementContainer
+    include ElementContainer
 
     attr_reader :root_element, :parent
 
@@ -53,10 +53,6 @@ module SitePrism
 
     def element_exists?(*find_args)
       root_element.has_selector?(*find_args) unless root_element.nil?
-    end
-
-    def element_does_not_exist?(*find_args)
-      root_element.has_no_selector?(*find_args) unless root_element.nil?
     end
   end
 end

--- a/lib/site_prism/version.rb
+++ b/lib/site_prism/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SitePrism
-  VERSION = '2.10'
+  VERSION = '2.10'.freeze
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -28,7 +28,7 @@ describe SitePrism::Page do
       element :thing, 'input#nonexistent'
     end
     page = PageWithElement.new
-    expect { page.has_no?(:thing) }.not_to raise_error
+    expect { page.no?(:thing) }.not_to raise_error
   end
 
   it 'should be able to wait for an element' do

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -7,12 +7,12 @@ describe SitePrism::Page do
     expect(SitePrism::Page).to respond_to :element
   end
 
-  it 'element method should generate existence check method' do
+  it 'should be able to check for element existence' do
     class PageWithElement < SitePrism::Page
       element :bob, 'a.b c.d'
     end
     page = PageWithElement.new
-    expect(page).to respond_to :has_bob?
+    expect { page.has?(:bob) }.not_to raise_error
   end
 
   it 'element method should generate method to return the element' do
@@ -23,12 +23,12 @@ describe SitePrism::Page do
     expect(page).to respond_to :bob
   end
 
-  it 'element method without css should generate existence check method' do
+  it 'should be able to check for css element nonexistence' do
     class PageWithElement < SitePrism::Page
       element :thing, 'input#nonexistent'
     end
     page = PageWithElement.new
-    expect(page).to respond_to :has_no_thing?
+    expect { page.has_no?(:thing) }.not_to raise_error
   end
 
   it 'should be able to wait for an element' do
@@ -36,7 +36,7 @@ describe SitePrism::Page do
       element :some_slow_element, 'a.slow'
     end
     page = PageWithElement.new
-    expect(page).to respond_to :wait_for_some_slow_element
+    expect { page.wait_for(:some_slow_element) }.not_to raise_error
   end
 
   it 'should know if all mapped elements are on the page' do
@@ -47,12 +47,12 @@ describe SitePrism::Page do
     expect(page).to respond_to :all_there?
   end
 
-  it 'element method with xpath should generate existence check method' do
+  it 'should be able to check for xpath element nonexistence' do
     class PageWithElement < SitePrism::Page
       element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
     end
     page = PageWithElement.new
-    expect(page).to respond_to :has_bob?
+    expect { page.has?(:bob) }.not_to raise_error
   end
 
   it 'element method with xpath should generate method to return the element' do
@@ -68,7 +68,7 @@ describe SitePrism::Page do
       element :some_slow_element, :xpath, '//a[@class="slow"]'
     end
     page = PageWithElement.new
-    expect(page).to respond_to :wait_for_some_slow_element
+    expect { page.wait_for(:some_slow_element) }.not_to raise_error
   end
 
   it 'should know if all mapped elements defined by xpath selector are on the page' do

--- a/spec/elements_spec.rb
+++ b/spec/elements_spec.rb
@@ -7,12 +7,12 @@ describe SitePrism::Page do
     expect(SitePrism::Page).to respond_to :elements
   end
 
-  it 'elements method should generate existence check method' do
+  it 'should be able to check for elements existence' do
     class PageWithElements < SitePrism::Page
       elements :bobs, 'a.b c.d'
     end
     page = PageWithElements.new
-    expect(page).to respond_to :has_bobs?
+    expect { page.has?(:bobs) }.not_to raise_error
   end
 
   it 'elements method should generate method to return the elements' do

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -30,7 +30,7 @@ describe SitePrism::Page do
         end
 
         page = YetAnotherPageWithASection.new
-        expect(page).to respond_to :has_something?
+        expect { page.has?(:something) }.not_to raise_error
       end
     end
 

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -7,7 +7,7 @@ describe SitePrism::Page do
     expect(SitePrism::Page).to respond_to :sections
   end
 
-  it 'should create a matching existence method for sections' do
+  it 'should be able to check for sections existence' do
     class SomePageWithSectionsThatNeedsTestingForExistence < SitePrism::Section
     end
 
@@ -20,8 +20,8 @@ describe SitePrism::Page do
     end
 
     page = YetAnotherPageWithSections.new
-    expect(page).to respond_to :has_some_things?
-    expect(page).to respond_to :has_other_things?
+    expect { page.has?(:some_things) }.not_to raise_error
+    expect { page.has?(:other_things) }.not_to raise_error
     # will throw a NoMethodError if methods overwritten by rspec matchers are called
     expect { page.other_things }.not_to raise_error
   end


### PR DESCRIPTION
clearly disambiguates the element name as the method argument

also prevents possible element name collision, consider:

    class MyPage < SitePrism::Page
      element :foo, '#foo'
      element :no_foo, '#no_foo'
    end

    page.has_no_foo? # ambiguous collision

previously metaprogrammed methods:

    page.has_foo?
    page.has_no_foo?
    page.wait_for_foo
    page.wait_until_foo_visible
    page.wait_until_foo_invisible

now:

    page.has?(:foo)
    page.has_no?(:foo)
    page.wait_for(:foo)
    page.wait_until_visible(:foo)
    page.wait_until_invisible(:foo)