### PR TITLE
Addressable / Rubocop Generic /lib Tidy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ ClassLength:
   Enabled: false
 
 LineLength:
-  Max: 160
+  Max: 130
 
 MethodLength:
   Max: 11

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -126,7 +126,8 @@ When(/^I wait for a specific amount of time until a particular element is invisi
 end
 
 Then(/^I get a timeout error when I wait for an element that never disappears$/) do
-  expect { @test_site.home.wait_until_welcome_header_invisible(1) }.to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
+  expect { @test_site.home.wait_until_welcome_header_invisible(1) }
+    .to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
 end
 
 Then(/^I do not wait for an nonexistent element when checking for invisibility$/) do
@@ -141,7 +142,8 @@ When(/^I wait for invisibility of an element embedded into a section which is re
 end
 
 Then(/^I receive an error when a section with the element I am waiting for is removed$/) do
-  expect { @test_site.home.container_with_element.wait_until_embedded_element_invisible }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.container_with_element.wait_until_embedded_element_invisible }
+    .to raise_error(Capybara::ElementNotFound)
 end
 
 Then(/^I can wait a variable time for elements to appear$/) do

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -182,7 +182,7 @@ module SitePrism
       elsif block_given?
         section_class = Class.new SitePrism::Section, &block
       else
-        raise ArgumentError, 'You should provide section class either as a block, or as the second argument'
+        raise ArgumentError, 'You should provide section class either as a block, or as the second argument.'
       end
       return section_class, args
     end

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -3,7 +3,13 @@
 module SitePrism
   class NoUrlForPage < StandardError; end
   class NoUrlMatcherForPage < StandardError; end
-  class InvalidUrlMatcher < StandardError; end
+
+  class InvalidUrlMatcher < StandardError
+    def message
+      'Could not automatically match your URL. Templated port numbers are unsupported.'
+    end
+  end
+
   class NoSelectorForElement < StandardError; end
   class TimeoutException < StandardError; end
   class TimeOutWaitingForElementVisibility < StandardError; end

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |s|
   s.email       = 'nat@natontesting.com'
   s.homepage    = 'http://github.com/natritmeyer/site_prism'
   s.summary     = 'A Page Object Model DSL for Capybara'
-  s.description = 'SitePrism gives you a simple, clean and semantic DSL for describing your site using the Page Object Model pattern, for use with Capybara'
+  s.description = 'SitePrism gives you a simple, clean and semantic DSL for describing your site.
+SitePrism implements the Page Object Model pattern, through its usage with Capybara.'
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/natritmeyer/site_prism'
   s.summary     = 'A Page Object Model DSL for Capybara'
   s.description = 'SitePrism gives you a simple, clean and semantic DSL for describing your site.
-SitePrism implements the Page Object Model pattern, through its usage with Capybara.'
+SitePrism implements the Page Object Model pattern on top of Capybara.'
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -53,9 +53,11 @@ describe SitePrism::Page do
       subject(:section) { Page.section(:incorrect_section, '.section') }
 
       it 'should raise an ArgumentError' do
-        class Page < SitePrism::Page
-        end
-        expect { section }.to raise_error ArgumentError, 'You should provide section class either as a block, or as the second argument'
+        class Page < SitePrism::Page; end
+
+        expect { section }
+          .to raise_error(ArgumentError)
+          .with_message('You should provide section class either as a block, or as the second argument')
       end
     end
   end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -10,8 +10,7 @@ describe SitePrism::Page do
   describe '.section' do
     context 'second argument is a Class' do
       it 'should create a method' do
-        class SomeSection < SitePrism::Section
-        end
+        class SomeSection < SitePrism::Section; end
 
         class PageWithSection < SitePrism::Page
           section :bob, SomeSection, '.bob'
@@ -22,14 +21,13 @@ describe SitePrism::Page do
       end
 
       it 'should create a matching existence method for a section' do
-        class SomePageWithSectionThatNeedsTestingForExistence < SitePrism::Section
+        class PageWithSectionToTestForExistence < SitePrism::Section; end
+
+        class AnotherPageWithASection < SitePrism::Page
+          section :something, PageWithSectionToTestForExistence, '.bob'
         end
 
-        class YetAnotherPageWithASection < SitePrism::Page
-          section :something, SomePageWithSectionThatNeedsTestingForExistence, '.bob'
-        end
-
-        page = YetAnotherPageWithASection.new
+        page = AnotherPageWithASection.new
         expect(page).to respond_to :has_something?
       end
     end
@@ -57,7 +55,7 @@ describe SitePrism::Page do
 
         expect { section }
           .to raise_error(ArgumentError)
-          .with_message('You should provide section class either as a block, or as the second argument')
+          .with_message('You should provide section class either as a block, or as the second argument.')
       end
     end
   end
@@ -80,7 +78,7 @@ describe SitePrism::Section do
   end
 
   it 'does not require a block' do
-    expect(Capybara).to_not receive(:within)
+    expect(Capybara).not_to receive(:within)
     SitePrism::Section.new(a_page, 'div')
   end
 


### PR DESCRIPTION
So this PR was intended to clear one of the tasks from the ever-growing TODO list but after a couple of days and not getting very far I've cut my losses.

This PR is non-breaking and does "some" refactoring around this class, which has way too much old style ruby for my liking.

I've also included a reduction to the `LineLength` metric. I didn't go all the way down to 80 to keep the PR reasonably small. But this at least does "some" of the required work.

In the 2nd commit SHA: https://github.com/natritmeyer/site_prism/commit/72248f1280970417b6817a701e939a38059f9996 I've explained what each individual small refactor is and how it's ok to do so