### PR TITLE
Clarify README for expected_elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,9 +716,10 @@ You may wish to have elements declared in a page object class that are not alway
 ```ruby
 class TestPage < SitePrism::Page
   element :name_field, '#name'
+  element :address_field, '#address'
   element :success_msg, 'span.alert-success'
 
-  expected_elements :name_field
+  expected_elements :name_field, :address_field
 end
 ```
 

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -24,7 +24,7 @@ module SitePrism
     alias collection elements
 
     def expected_elements(*elements)
-      @expected_items = elements.map(&:to_s)
+      @expected_items = elements
     end
 
     def section(section_name, *args, &block)
@@ -64,7 +64,7 @@ module SitePrism
 
     def add_to_mapped_items(item)
       @mapped_items ||= []
-      @mapped_items << item.to_s
+      @mapped_items << item
     end
 
     def raise_if_block(obj, name, has_block)


### PR DESCRIPTION
A quick follow-up to #208.

NOTE: In reading about load validations via `Loadable`, I'm now somewhat concerned that `all_there?` modified by `expected_elements` is a tad obselete. When I originally submitted #98 (which is what inspired #208) I'm fairly sure `Loadable` wasn't implemented yet (or maybe it was and I didn't notice).

In any event, as long as we have the `expected_elements` construct, we'll want the README to be clear on how to use it.