### PR TITLE
Support all selector types for iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ end
 To expose the iframe, reference it from another page or class using the `iframe`
 method. The `iframe` method takes 3 arguments; the name by which you
 would like to reference the iframe, the page class that represents the
-iframe, and an ID or class by which you can locate the iframe. For example:
+iframe, and the CSS selector by which you can locate the iframe. For example:
 
 ```ruby
 class PageContainingIframe < SitePrism::Page
@@ -1525,8 +1525,21 @@ class PageContainingIframe < SitePrism::Page
 end
 ```
 
-The third argument to the `iframe` method must
-contain a selector that will locate the iframe node.
+### Locating an iframe
+
+While the above example uses a CSS selector to find the iframe, it is also
+possible to use an XPath expression or the index of the iframe in its parent
+(a shortcut for an `nth-of-type` CSS selector). For example:
+
+```ruby
+class PageContainingIframe < SitePrism::Page
+  # XPath Expression:
+  iframe :my_iframe, MyIframe, :xpath, '//iframe[@id="my_iframe_id"]'
+
+  # Index (nth-of-type) Selector:
+  iframe :my_iframe, MyIframe, 0
+end
+```
 
 ### Testing for an iframe's existence
 

--- a/features/iframes.feature
+++ b/features/iframes.feature
@@ -7,6 +7,17 @@ Feature: IFrame interaction
   Scenario: locate an iframe by index
     When I navigate to the home page
     Then I can locate the iframe by index
+    And I can see elements in an indexed iframe
+
+  Scenario: locate an iframe by name
+    When I navigate to the home page
+    Then I can locate the iframe by name
+    And I can see elements in a named iframe
+
+  Scenario: locate an iframe by xpath
+    When I navigate to the home page
+    Then I can locate the iframe by xpath
+    And I can see elements in an xpath iframe
 
   Scenario: interact with elements in an iframe
     When I navigate to the home page

--- a/features/step_definitions/iframe_steps.rb
+++ b/features/step_definitions/iframe_steps.rb
@@ -12,8 +12,38 @@ Then(/^I can locate the iframe by index$/) do
   expect(@test_site.home).to have_index_iframe
 end
 
+Then(/^I can locate the iframe by name$/) do
+  @test_site.home.wait_for_named_iframe
+
+  expect(@test_site.home).to have_named_iframe
+end
+
+Then(/^I can locate the iframe by xpath$/) do
+  @test_site.home.wait_for_xpath_iframe
+
+  expect(@test_site.home).to have_xpath_iframe
+end
+
 Then(/^I can see elements in an iframe$/) do
   @test_site.home.my_iframe do |f|
+    expect(f.some_text.text).to eq('Some text in an iframe')
+  end
+end
+
+Then(/^I can see elements in an indexed iframe$/) do
+  @test_site.home.index_iframe do |f|
+    expect(f.some_text.text).to eq('Some text in an iframe')
+  end
+end
+
+Then(/^I can see elements in a named iframe$/) do
+  @test_site.home.named_iframe do |f|
+    expect(f.some_text.text).to eq('Some text in an iframe')
+  end
+end
+
+Then(/^I can see elements in an xpath iframe$/) do
+  @test_site.home.xpath_iframe do |f|
     expect(f.some_text.text).to eq('Some text in an iframe')
   end
 end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -48,15 +48,15 @@ module SitePrism
       end
     end
 
-    def iframe(iframe_name, iframe_page_class, selector)
-      element_selector = deduce_iframe_element_selector(selector)
-      scope_selector = deduce_iframe_scope_selector(selector)
+    def iframe(iframe_name, iframe_page_class, *args)
+      element_find_args = deduce_iframe_element_find_args(args)
+      scope_find_args = deduce_iframe_scope_find_args(args)
       add_to_mapped_items iframe_name
-      create_existence_checker iframe_name, element_selector
-      create_nonexistence_checker iframe_name, element_selector
-      create_waiter iframe_name, element_selector
+      create_existence_checker iframe_name, *element_find_args
+      create_nonexistence_checker iframe_name, *element_find_args
+      create_waiter iframe_name, *element_find_args
       define_method iframe_name do |&block|
-        within_frame scope_selector do
+        within_frame(*scope_find_args) do
           block.call iframe_page_class.new
         end
       end
@@ -169,12 +169,26 @@ module SitePrism
       end
     end
 
-    def deduce_iframe_scope_selector(selector)
-      selector.is_a?(Integer) ? selector : selector.split('#').last
+    def deduce_iframe_scope_find_args(args)
+      case args[0]
+      when Integer
+        [args[0]]
+      when String
+        [:css, args[0]]
+      else
+        args
+      end
     end
 
-    def deduce_iframe_element_selector(selector)
-      selector.is_a?(Integer) ? "iframe:nth-of-type(#{selector + 1})" : selector
+    def deduce_iframe_element_find_args(args)
+      case args[0]
+      when Integer
+        "iframe:nth-of-type(#{args[0] + 1})"
+      when String
+        [:css, args[0]]
+      else
+        args
+      end
     end
 
     def extract_section_options(args, &block)

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -17,7 +17,7 @@ SitePrism implements the Page Object Model pattern on top of Capybara.'
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']
-  s.add_dependency 'capybara', ['~> 2.7']
+  s.add_dependency 'capybara', ['~> 2.12']
 
   s.add_development_dependency 'cucumber', ['2.4.0']
   s.add_development_dependency 'rake', ['>= 11.0']

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -68,6 +68,6 @@
     <input type='submit' id='will_become_invisible' value='Will become invisible' style='display: block;'/>
     <input type='submit' class='invisible' value='Invisible' style='display: none;'/>
 
-    <iframe id='the_iframe' src='my_iframe.htm'></iframe>
+    <iframe id='the_iframe' name='the_iframe' src='my_iframe.htm'></iframe>
   </body>
 </html>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -33,4 +33,6 @@ class TestHomePage < SitePrism::Page
   # iframes
   iframe :my_iframe, MyIframe, '#the_iframe'
   iframe :index_iframe, MyIframe, 0
+  iframe :named_iframe, MyIframe, '[name="the_iframe"]'
+  iframe :xpath_iframe, MyIframe, :xpath, '//iframe[@name="the_iframe"]'
 end


### PR DESCRIPTION
This PR fixes #118 by modifying the behavior of the iframe locator argument to use the CSS option for find when passed a string, and supporting all other options for locating an iframe:

```
iframe :my_iframe, MyIframe, '#the_iframe' # Use `:css` selector now instead of `:frame`
iframe :index_iframe, MyIframe, 0 # Use index selector as before
iframe :named_iframe, MyIframe, '[name=the_iframe]' # Use `:css` selector now
iframe :xpath_iframe, MyIframe, :xpath, '//iframe[@name="the_iframe"]' # Support `:xpath` selector
```

This also requires a update to the minimum version of Capybara to 2.12 where support for more selectors was added https://github.com/teamcapybara/capybara/commit/53b99af750277addae617268d4c57ad418fc63d1