### PR TITLE
Cucumber / Step Cleaner

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 ### Backlog:
 -  code-coverage - line to fix up: `spec/page_spec.rb:91`
--  Fix `page_element_interaction_steps.rb`: Triple Expectations and non-Helper expectation
--  Fix `page_section_steps.rb` - Triple expectations
 -  Look to rework suite-wide Gherkin
     - Introduce Hooks to cache Page objects on a per-test basis (Should save a few fractions)
     - Don't memoize the individual page calls just incase (Also goes against readme)
@@ -22,7 +20,7 @@ people wanting to access the base native object (Honouring what maintainers said
 -  Rubocop MethodLength reduction (Should be a small-er PR)
 -  Begin to start using let blocks across specs (Dev points update)
 -  Add developmental guidelines / setup information
--  Review iFrame specs, add/amend where appropriate
+-  Create iFrame specs (Even though private methods)
 -  Allow scoping iFrames to then be passed into element native object
 - Generic suite wide linting in `/lib` need to wrap method arguments up (Remove space separations)
 - Generic spec walkthrough - (have done `sections_spec.rb` - which might need renaming)

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,10 @@
 -  code-coverage - line to fix up: `spec/page_spec.rb:91`
 -  Fix `page_element_interaction_steps.rb`: Triple Expectations and non-Helper expectation
 -  Fix `page_section_steps.rb` - Triple expectations
--  Generic Features are sometimes hard to understand. Look to rework the Gherkin
+-  Look to rework suite-wide Gherkin
+    - Introduce Hooks to cache Page objects on a per-test basis (Should save a few fractions)
+    - Don't memoize the individual page calls just incase (Also goes against readme)
+    - Expand on existing large scale features and try tear down into more relevant ones
 -  `page_element_interaction_steps.rb:49` Shouldn't be there as its performing Actions
 -  Now Capybara is 2.6+
     - capybara 2.5 was the first Capybara to introduce `default_max_wait_time`
@@ -11,23 +14,15 @@
 -  `site_prism/addressable_url_matcher.rb` - Needs more of a spring clean
 -  `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
 -  Begin to refactor `displayed?(*args)`, to remove enumerable args (Shouldn't be enumerable)
--  iFrame helper methods - Potential bug to fix (Issue #66)
 -  New feature `SitePrism::Section#native` returning `root_element.native` To help with
 people wanting to access the base native object (Honouring what maintainers said)
--  Exceptions Spec needs writing
 -  element/s spec need a slight rename / tidy
--  Release 2.11 to Rubygems
 -  Update of Ruby Version to supported version
--  Generic Update of dependencies (Unrestrict everything we don't care about)
 -  Rubocop LineLength reduction (Continue this, will be hard work, probably several PR's)
 -  Rubocop MethodLength reduction (Should be a small-er PR)
 -  Begin to start using let blocks across specs (Dev points update)
 -  Add developmental guidelines / setup information
 -  Review iFrame specs, add/amend where appropriate
--  Allow scoping iframes to then be passed into element native object
-- `.gitignore` review RE different development environments - Needs Mac/Windows/Other dev input
+-  Allow scoping iFrames to then be passed into element native object
 - Generic suite wide linting in `/lib` need to wrap method arguments up (Remove space separations)
-- Generic spec walkthrough - (have done setions_spec.rb - which might need renaming)
-
-### To monitor (Assumed fixed elsewhere)
--  Capybara compatibility around iFrames - Now should be more compatible. Remove once 2.12 is released
+- Generic spec walkthrough - (have done `sections_spec.rb` - which might need renaming)

--- a/features/iframes.feature
+++ b/features/iframes.feature
@@ -11,5 +11,4 @@ Feature: IFrame interaction
 
   Scenario: interact with elements in an iframe
     Then I can see elements in an iframe
-    Then I can see elements in an iframe with capybara query options
-    And I can see an expected bit of text
+    And I can see elements in an iframe with capybara query options

--- a/features/iframes.feature
+++ b/features/iframes.feature
@@ -1,15 +1,15 @@
 Feature: IFrame interaction
 
-  Scenario: locate an iframe by id
+  Background:
     When I navigate to the home page
+
+  Scenario: locate an iframe by id
     Then I can locate the iframe by id
 
   Scenario: locate an iframe by index
-    When I navigate to the home page
     Then I can locate the iframe by index
 
   Scenario: interact with elements in an iframe
-    When I navigate to the home page
     Then I can see elements in an iframe
     Then I can see elements in an iframe with capybara query options
     And I can see an expected bit of text

--- a/features/navigation.feature
+++ b/features/navigation.feature
@@ -1,7 +1,4 @@
-Feature: Page navigation
-  As a tester
-  I want to be able to point my test at a page
-  In order to interact with it
+Feature: Page Navigation
 
   Scenario: Navigate to a page
     When I navigate to the home page
@@ -14,7 +11,7 @@ Feature: Page navigation
   Scenario: Wait to be redirected to a page
     When I navigate to the redirect page
     Then I am on the redirect page
-      And I will be redirected to the home page
+    And I will be redirected to the home page
 
   Scenario: Navigate to the wrong page
     When I navigate to the home page

--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -32,17 +32,17 @@ Feature: Page element interaction
 
   Scenario: Wait for element
     When I navigate to the home page
-    Then when I wait for the element that takes a while to appear
-    Then I successfully wait for it to appear
+    And I wait for the element that takes a while to appear
+    Then the slow element appears
 
   Scenario: Wait specific amount of time for element to appear
     When I navigate to the home page
-    And I wait for a specifically short amount of time for an element to appear
+    And I wait for a short amount of time for an element to appear
     Then the element I am waiting for doesn't appear in time
 
-  Scenario: Check that all elements are present
+  Scenario: Page without `expected_elements`
     When I navigate to the home page
-    Then all expected elements are present
+    Then not all expected elements are present
 
   Scenario: Page with `expected_elements`
     When I navigate to the home page that contains expected elements

--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -69,7 +69,7 @@ Feature: Page element interaction
 
   Scenario: Wait for invisibility of element
     When I navigate to the home page
-    And I wait while for an element to become invisible
+    And I wait for an element to become invisible
     Then the previously visible element is invisible
 
   Scenario: Wait specific amount of time for invisibility of element

--- a/features/page_elements_interaction.feature
+++ b/features/page_elements_interaction.feature
@@ -2,20 +2,18 @@ Feature: Interaction with groups of elements
 
   I want to be able to interact with element collections on a page
 
-  Scenario: Get groups of elements
+  Background:
     When I navigate to the home page
-    Then I can see the group of links
-    And I can get the text values for the group of links
+
+  Scenario: Get text from group of elements
+    Then I can get the text values for the group of links
 
   Scenario: Get groups of elements from within a section
-    When I navigate to the home page
     Then I can see individual people in the people list
 
   Scenario: Page with no elements
-    When I navigate to the home page
-    Then the page does not have elements
+    Then the page does not have a group of elements
 
   Scenario: Waiting on a set of elements
-    When I navigate to the home page
-    And I wait a variable time for elements to appear
+    When I wait a variable time for elements to appear
     Then I can wait a variable time and pass specific parameters

--- a/features/page_elements_interaction.feature
+++ b/features/page_elements_interaction.feature
@@ -1,12 +1,11 @@
 Feature: Interaction with groups of elements
-  As a tester
+
   I want to be able to interact with element collections on a page
-  In order to get and set values on the page
 
   Scenario: Get groups of elements
     When I navigate to the home page
     Then I can see the group of links
-    And I can get the group of links
+    And I can get the text values for the group of links
 
   Scenario: Get groups of elements from within a section
     When I navigate to the home page
@@ -18,5 +17,5 @@ Feature: Interaction with groups of elements
 
   Scenario: Waiting on a set of elements
     When I navigate to the home page
-    Then I can wait a variable time for elements to appear
+    And I wait a variable time for elements to appear
     Then I can wait a variable time and pass specific parameters

--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -6,12 +6,13 @@ Feature: Page Sections
   Scenario: Designate a section of a page
     When I navigate to the home page
     Then I can see elements in the section
-    When I navigate to another page
-    Then that section is there too
+    When I navigate to the people page
+    Then I can see a list of people
 
   Scenario: access elements in the section by passing a block
     When I navigate to the home page
     Then I can access elements within the section using a block
+    But I cannot access elements not in the section using a block
 
   Scenario: section in a section
     When I navigate to the section experiments page

--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -53,10 +53,10 @@ Feature: Page Sections
     When I navigate to the section experiments page
     Then I can run javascript against the search results
 
-  Scenario: Wait for section element
+  Scenario: Wait for section
     When I navigate to the section experiments page
-    Then when I wait for the section element that takes a while to appear
-    Then I successfully wait for the slow section element to appear
+    And I wait for the section element that takes a while to appear
+    Then the slow section appears
 
   Scenario: Get parent belonging to section
     When I navigate to the home page
@@ -86,6 +86,6 @@ Feature: Page Sections
     When I navigate to the section experiments page
     Then the page contains a deeply nested span
 
-  Scenario: get text from page secion
+  Scenario: get text from page section
     When I navigate to the home page
-    Then I can see a section's full text 
+    Then I can see a section's full text

--- a/features/properties.feature
+++ b/features/properties.feature
@@ -1,10 +1,7 @@
-Feature: Page properties
-  As a tester
-  I want to be able to get properties of the page
-  In order to know more about the page
+Feature: Page Properties
 
   Background:
-    Given I navigate to the home page
+    When I navigate to the home page
 
   Scenario: Get page html
     Then I can see an expected bit of the html

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,23 +1,31 @@
 # frozen_string_literal: true
 
 When(/^I navigate to the home page$/) do
-  @test_site = TestSite.new
   @test_site.home.load
 end
 
 When(/^I navigate to the home page that contains expected elements$/) do
-  @test_site = TestSite.new
   @test_site.home_with_expected_elements.load
 end
 
 When(/^I navigate to the letter A page$/) do
-  @test_site = TestSite.new
   @test_site.dynamic_page.load(letter: 'a')
 end
 
 When(/^I navigate to the redirect page$/) do
-  @test_site = TestSite.new
   @test_site.redirect_page.load
+end
+
+When(/^I navigate to a page with no title$/) do
+  @test_site.no_title.load
+end
+
+When(/^I navigate to another page$/) do
+  @test_site.page_with_people.load
+end
+
+When(/^I navigate to the section experiments page$/) do
+  @test_site.section_experiments.load
 end
 
 Then(/^I am on the home page$/) do
@@ -38,18 +46,4 @@ end
 
 Then(/^I will be redirected to the home page$/) do
   expect(@test_site.home).to be_displayed
-end
-
-When(/^I navigate to a page with no title$/) do
-  @test_site = TestSite.new
-  @test_site.no_title.load
-end
-
-When(/^I navigate to another page$/) do
-  @test_site.page_with_people.load
-end
-
-When(/^I navigate to the section experiments page$/) do
-  @test_site = TestSite.new
-  @test_site.section_experiments.load
 end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -20,7 +20,7 @@ When(/^I navigate to a page with no title$/) do
   @test_site.no_title.load
 end
 
-When(/^I navigate to another page$/) do
+When(/^I navigate to the people page$/) do
   @test_site.page_with_people.load
 end
 

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -120,7 +120,7 @@ Then(/^I get a timeout error when I wait for an element that never appears$/) do
     .to raise_error(SitePrism::TimeOutWaitingForElementVisibility)
 end
 
-When(/^I wait while for an element to become invisible$/) do
+When(/^I wait for an element to become invisible$/) do
   @test_site.home.wait_until_retiring_element_invisible
 end
 

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -14,7 +14,7 @@ Then(/^the page does not have element$/) do
   expect(@test_site.home).to have_no_nonexistent_element
 end
 
-Then(/^the page does not have elements$/) do
+Then(/^the page does not have a group of elements$/) do
   expect(@test_site.home.has_no_nonexistent_elements?).to be true
 
   expect(@test_site.home).to have_no_nonexistent_elements
@@ -67,10 +67,6 @@ Then(/^I cannot see the missing other thingy$/) do
   using_wait_time(0) do
     expect(@test_site.home).not_to have_other_thingy
   end
-end
-
-Then(/^I can see the group of links$/) do
-  expect(@test_site.home).to have_lots_of_links
 end
 
 Then(/^I can get the text values for the group of links$/) do

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -73,7 +73,7 @@ Then(/^I can see the group of links$/) do
   expect(@test_site.home).to have_lots_of_links
 end
 
-Then(/^I can get the group of links$/) do
+Then(/^I can get the text values for the group of links$/) do
   expect(@test_site.home.lots_of_links.map(&:text)).to eq(%w[a b c])
 end
 
@@ -153,7 +153,7 @@ Then(/^I receive an error when a section with the element I am waiting for is re
     .to raise_error(Capybara::ElementNotFound)
 end
 
-Then(/^I can wait a variable time for elements to appear$/) do
+When(/^I wait a variable time for elements to appear$/) do
   @test_site.home.wait_for_lots_of_links
   @test_site.home.wait_for_lots_of_links(0.1)
 end

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -77,7 +77,7 @@ Then(/^I can get the group of links$/) do
   expect(@test_site.home.lots_of_links.map(&:text)).to eq(%w[a b c])
 end
 
-Then(/^all expected elements are present$/) do
+Then(/^not all expected elements are present$/) do
   expect(@test_site.home).not_to be_all_there
 end
 

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -2,7 +2,7 @@
 
 Then(/^I can see elements in the section$/) do
   expect(@test_site.home).to have_people
-  expect(@test_site.home.people.headline).to have_content('People')
+
   expect(@test_site.home.people).to have_headline(text: 'People')
 end
 
@@ -13,26 +13,27 @@ end
 Then(/^I can access elements within the section using a block$/) do
   expect(@test_site.home).to have_people
 
-  @test_site.home.people do |persons|
-    expect(persons).to have_headline(text: 'People')
-    expect(persons.headline.text).to eq('People')
-    expect(persons).to have_no_dinosaur
-    expect(persons).to have_individuals(count: 4)
+  @test_site.home.people do |section|
+    expect(section.headline.text).to eq('People')
+
+    expect(section).to have_individuals(count: 4)
   end
 
   # the above would pass if the block were ignored, this verifies it is executed:
   expect do
-    @test_site.home.people { |p| expect(p).to have_dinosaur }
+    @test_site.home.people { |section| expect(section).to have_dinosaur }
   end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 
 Then(/^access to elements is constrained to those within the section$/) do
-  expect(@test_site.home).to have_css('span.welcome')
+  expect(@test_site.home).to have_css('.welcome')
 
-  @test_site.home.people do |persons|
-    expect(persons).to have_no_css('.welcome')
-    expect { persons.has_welcome_message? }.to raise_error(NoMethodError)
-    expect(persons).to have_no_welcome_message_on_the_parent
+  expect(@test_site.home.has_welcome_message?).to be true
+
+  @test_site.home.people do |section|
+    expect(section).to have_no_css('.welcome')
+
+    expect { section.has_welcome_message? }.to raise_error(NoMethodError)
   end
 end
 
@@ -44,16 +45,16 @@ end
 
 Then(/^that section is there too$/) do
   expect(@test_site.page_with_people).to have_people_list
+
   expect(@test_site.page_with_people.people_list.headline).to have_content('People')
-  expect(@test_site.page_with_people.people_list).to have_headline(text: 'People')
 end
 
 Then(/^I can see a section within a section using nested blocks$/) do
   expect(@test_site.section_experiments).to have_parent_section
 
   @test_site.section_experiments.parent_section do |parent|
-    expect(parent).to have_child_section
     expect(parent.child_section.nice_label.text).to eq('something')
+
     parent.child_section do |child|
       expect(child).to have_nice_label(text: 'something')
     end
@@ -61,35 +62,27 @@ Then(/^I can see a section within a section using nested blocks$/) do
 end
 
 Then(/^I can see a collection of sections$/) do
-  expect(@test_site.section_experiments).to have_search_results
-
   @test_site.section_experiments.search_results.each_with_index do |search_result, i|
     expect(search_result.title.text).to eq("title #{i}")
-    expect(search_result.link.text).to eq("link #{i}")
+
     expect(search_result.description.text).to eq("description #{i}")
   end
-  expect(@test_site.section_experiments.search_results.size).to eq(4)
 
-  expect(@test_site.section_experiments.search_results(count: 4).size).to eq(4)
+  expect(@test_site.section_experiments.search_results.size).to eq(4)
 end
 
 Then(/^I can see an anonymous section$/) do
-  expect(@test_site.section_experiments).to have_anonymous_section
   expect(@test_site.section_experiments.anonymous_section.title.text).to eq('Anonymous Section')
-  expect(@test_site.section_experiments.anonymous_section.upcase_title_text).to eq('ANONYMOUS SECTION')
 end
 
 Then(/^I can see a collection of anonymous sections$/) do
-  expect(@test_site.section_experiments).to have_anonymous_section
-
   @test_site.section_experiments.anonymous_sections.each_with_index do |section, i|
     expect(section.title.text).to eq("Section #{i}")
+
     expect(section.downcase_title_text).to eq("section #{i}")
   end
 
   expect(@test_site.section_experiments.anonymous_sections.size).to eq(2)
-
-  expect(@test_site.section_experiments.anonymous_sections(count: 2).size).to eq(2)
 end
 
 Then(/^the section is visible$/) do
@@ -106,13 +99,13 @@ end
 
 Then(/^I can run javascript against the search results$/) do
   @test_site.section_experiments.search_results.first.set_cell_value
+
   expect(@test_site.section_experiments.search_results.first.cell_value).to eq('wibble')
-  expect(@test_site.section_experiments.search_results.first.cell_value).to have_content('wibble')
 end
 
 Then(/^I can see individual people in the people list$/) do
   expect(@test_site.home.people.individuals.size).to eq(4)
-  expect(@test_site.home.people.individuals(count: 4).size).to eq(4)
+
   expect(@test_site.home.people).to have_individuals(count: 4)
 end
 
@@ -148,7 +141,6 @@ Then(/^the page contains a deeply nested span$/) do
   deeply_nested_section =
     @test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0]
 
-  expect(deeply_nested_section).to have_deep_span
   expect(deeply_nested_section.deep_span.text).to eq('Deep span')
 end
 

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -18,8 +18,9 @@ Then(/^I can access elements within the section using a block$/) do
 
     expect(section).to have_individuals(count: 4)
   end
+end
 
-  # the above would pass if the block were ignored, this verifies it is executed:
+Then(/^I cannot access elements not in the section using a block$/) do
   expect do
     @test_site.home.people { |section| expect(section).to have_dinosaur }
   end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
@@ -43,9 +44,7 @@ Then(/^the page does not have a section$/) do
   expect(@test_site.home).to have_no_nonexistent_section
 end
 
-Then(/^that section is there too$/) do
-  expect(@test_site.page_with_people).to have_people_list
-
+Then(/^I can see a list of people$/) do
   expect(@test_site.page_with_people.people_list.headline).to have_content('People')
 end
 

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -9,7 +9,7 @@ Then(/^the slow element appears$/) do
 end
 
 When(/^I wait for a short amount of time for an element to appear$/) do
-  @test_site.home.wait_for_some_slow_element(2)
+  @test_site.home.wait_for_some_slow_element(1)
 end
 
 Then(/^the element I am waiting for doesn't appear in time$/) do

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-Then(/^when I wait for the element that takes a while to appear$/) do
+When(/^I wait for the element that takes a while to appear$/) do
   @test_site.home.wait_for_some_slow_element
 end
 
-Then(/^I successfully wait for it to appear$/) do
+Then(/^the slow element appears$/) do
   expect(@test_site.home).to have_some_slow_element
 end
 
-When(/^I wait for a specifically short amount of time for an element to appear$/) do
+When(/^I wait for a short amount of time for an element to appear$/) do
   @test_site.home.wait_for_some_slow_element(2)
 end
 
 Then(/^the element I am waiting for doesn't appear in time$/) do
-  expect(@test_site.home).not_to be_all_there
+  expect(@test_site.home).not_to have_some_slow_element
 end
 
-Then(/^when I wait for the section element that takes a while to appear$/) do
+When(/^I wait for the section element that takes a while to appear$/) do
   @test_site.section_experiments.parent_section.wait_for_slow_section_element
 end
 
-Then(/^I successfully wait for the slow section element to appear$/) do
+Then(/^the slow section appears$/) do
   expect(@test_site.section_experiments.parent_section).to have_slow_section_element
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,3 @@
+Before do
+  @test_site = TestSite.new
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -362,9 +362,9 @@ describe SitePrism::Page do
   end
 
   it 'should raise an exception if passing a block to sections' do
-    expect { TestHomePage.new.nonexistent_section { :any_old_block } }
+    expect { TestHomePage.new.nonexistent_sections { :any_old_block } }
       .to raise_error(SitePrism::UnsupportedBlock)
-      .with_message('TestHomePage#nonexistent_section does not accept blocks, did you mean to define a (i)frame?')
+      .with_message('TestHomePage#nonexistent_sections does not accept blocks, did you mean to define a (i)frame?')
   end
 
   def swap_current_url(url)

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -9,7 +9,7 @@ class TestHomePage < SitePrism::Page
   element :welcome_message, :xpath, '//span'
   element :go_button, :xpath, '//input'
   element :link_to_search_page, :xpath, '//a'
-  element :some_slow_element, :xpath, '//a[@class="slow"]'
+  element :some_slow_element, :xpath, '//a[@class="slow"]' # This takes just over 2 seconds to appear
   element :invisible_element, 'input.invisible'
   element :shy_element, 'input#will_become_visible'
   element :retiring_element, 'input#will_become_invisible'

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -28,7 +28,7 @@ class TestHomePage < SitePrism::Page
   section :people, People, '.people'
   section :container_with_element, ContainerWithElement, '#container_with_element'
   section :nonexistent_section, NoElementWithinSection, 'input#nonexistent'
-  sections :nonexistent_section, NoElementWithinSection, 'input#nonexistent'
+  sections :nonexistent_sections, NoElementWithinSection, 'input#nonexistent'
 
   # iframes
   iframe :my_iframe, MyIframe, '#the_iframe'

--- a/test_site/pages/section_experiments.rb
+++ b/test_site/pages/section_experiments.rb
@@ -9,10 +9,6 @@ class TestSectionExperiments < SitePrism::Page
 
   section :anonymous_section, '.anonymous-section' do
     element :title, 'h1'
-
-    def upcase_title_text
-      title.text.upcase
-    end
   end
 
   sections :anonymous_sections, 'ul.anonymous-sections li' do

--- a/test_site/sections/search_result.rb
+++ b/test_site/sections/search_result.rb
@@ -2,7 +2,6 @@
 
 class SearchResult < SitePrism::Section
   element :title, 'span.title'
-  element :link, 'a'
   element :description, 'span.description'
 
   def set_cell_value


### PR DESCRIPTION
Removed quite a few duplicate / superfluous specs that were basically doing the same thing several times over.

Tried to establish a standard of not wanting to test a parent item for existence and then a child item for anything (As we must have an existent parent in order to interrogate the child) <- This also will essentially fail with `NoMethodError` but on a very specific call otherwise, which is the same as what we had before, just not in RSpec territory.

Also started to DRY up some suite loading stuff using Cucumber Hooks. For now I've just put in a basic creation, I've yet to memoize anything, I wasn't wanting to do anything too drastic just yet.

I've also just generally tried to make the overall feel much clearer with regards to naming e.t.c. There still is more work to do especially around breaking the code out into more manageable chunks but for now this does a good interim job of making the suite run a little faster, a bit more concise, and with fewer overlap points.