### PR TITLE
New Feature: Section#native

### DIFF
--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -89,3 +89,7 @@ Feature: Page element interaction
     When I navigate to the home page
     And I wait for invisibility of an element embedded into a section which is removed
     Then I receive an error when a section with the element I am waiting for is removed
+
+  Scenario: Get native property from element
+    When I navigate to the home page
+    Then I can obtain the native property of an element

--- a/features/page_sections.feature
+++ b/features/page_sections.feature
@@ -86,6 +86,10 @@ Feature: Page Sections
     When I navigate to the section experiments page
     Then the page contains a deeply nested span
 
-  Scenario: get text from page secion
+  Scenario: get text from page section
     When I navigate to the home page
-    Then I can see a section's full text 
+    Then I can see a section's full text
+
+  Scenario: Get native property from section
+    When I navigate to the home page
+    Then I can obtain the native property of a section

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -165,3 +165,11 @@ Then(/^I can wait a variable time and pass specific parameters$/) do
     expect(@test_site.home.wait_for_lots_of_links(nil, count: 198_108_14)).to be false
   end
 end
+
+Then(/^I can obtain the native property of an element$/) do
+  expect(@test_site.home.welcome_header.native).to be_a Selenium::WebDriver::Element
+end
+
+Then(/^I can obtain the native property of a section$/) do
+  expect(@test_site.home.people.native).to be_a Selenium::WebDriver::Element
+end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -26,11 +26,11 @@ module SitePrism
     end
 
     def execute_script(input)
-      Capybara.current_session.execute_script input
+      Capybara.current_session.execute_script(input)
     end
 
     def evaluate_script(input)
-      Capybara.current_session.evaluate_script input
+      Capybara.current_session.evaluate_script(input)
     end
 
     def parent_page

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -41,6 +41,10 @@ module SitePrism
       candidate_page
     end
 
+    def native
+      root_element.native
+    end
+
     private
 
     def find_first(*find_args)

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -2,45 +2,41 @@
 
 require 'spec_helper'
 
+class Section < SitePrism::Section; end
+class Page < SitePrism::Page; end
+
 describe SitePrism::Page do
   describe '.section' do
-    class Page < SitePrism::Page; end
-    class Section < SitePrism::Section; end
-
-    class PageWithAnonymousSection < SitePrism::Page
-      section :anonymous_section, '.section' do |s|
-        s.element :title, 'h1'
-      end
-    end
-
-    class PageWithSection < SitePrism::Page
-      section :section, Section, '.section'
-    end
-
     context 'second argument is a Class' do
-      subject { PageWithSection.new }
-
-      it 'should create a section using the Class' do
-        expect(subject).to respond_to(:section)
+      class PageWithSection < SitePrism::Page
+        section :section, Section, '.section'
       end
+
+      subject(:page_with_section) { PageWithSection.new }
+
+      it { is_expected.to respond_to(:section) }
     end
 
     context 'second argument is not a Class and a block given' do
-      subject { PageWithAnonymousSection.new }
-
-      it 'should create an anonymous section using the block' do
-        expect(subject).to respond_to(:anonymous_section)
+      class PageWithAnonymousSection < SitePrism::Page
+        section :anonymous_section, '.section' do |s|
+          s.element :title, 'h1'
+        end
       end
+
+      subject(:page_with_anonymous_section) { PageWithAnonymousSection.new }
+
+      it { is_expected.to respond_to(:anonymous_section) }
     end
 
     context 'second argument is not a Class and no block given' do
-      subject { Page.section(:incorrect_section, '.section') }
+      subject(:invalid_page) { Page.section(:incorrect_section, '.section') }
       let(:error_message) do
         'You should provide section class either as a block, or as the second argument.'
       end
 
-      it 'should raise an ArgumentError' do
-        expect { subject }
+      it 'raises an ArgumentError' do
+        expect { invalid_page }
           .to raise_error(ArgumentError)
           .with_message(error_message)
       end
@@ -49,85 +45,98 @@ describe SitePrism::Page do
 end
 
 describe SitePrism::Section do
-  class Page < SitePrism::Page; end
-
-  subject { SitePrism::Section.new(Page.new, locator) }
-  let(:locator) { object_double(Capybara::Node::Element.new(:foo, :bar, :baz, :ignore)) }
+  let(:instance) { SitePrism::Section.new(Page.new, locator) }
+  let(:locator) { instance_double('Capybara::Node::Element') }
   let(:section_with_block) { SitePrism::Section.new(Page.new, locator) { 1 + 1 } }
 
-  it 'responds to element' do
-    expect(SitePrism::Section).to respond_to(:element)
+  describe 'Object' do
+    subject { SitePrism::Section }
+
+    it { is_expected.to respond_to(:element) }
+    it { is_expected.to respond_to(:elements) }
   end
 
-  it 'responds to elements' do
-    expect(SitePrism::Section).to respond_to(:elements)
+  describe '#new' do
+    context 'with a block' do
+      it 'passes the block to Capybara.within' do
+        expect(Capybara).to receive(:within).with(locator)
+
+        section_with_block
+      end
+    end
+
+    context 'without a block' do
+      it 'does not pass a block to Capybara.within' do
+        expect(Capybara).not_to receive(:within)
+
+        instance
+      end
+    end
   end
 
-  describe 'instance' do
-    it 'passes a given block to Capybara.within' do
-      expect(Capybara).to receive(:within).with(locator)
-
-      section_with_block
-    end
-
-    it 'does not require a block' do
-      expect(Capybara).not_to receive(:within)
-
-      subject
-    end
-
-    it 'evaluates visibility by delegating through root_element' do
+  describe '#visible?' do
+    it 'delegates through root_element' do
       expect(locator).to receive(:visible?)
 
-      subject.visible?
+      instance.visible?
     end
+  end
 
-    it 'obtains the text of a section by delegating through root_element' do
+  describe '#text' do
+    it 'delegates through root_element' do
       expect(locator).to receive(:text)
 
-      subject.text
+      instance.text
     end
+  end
 
-    it 'obtains the native property of a section by delegating through root_element' do
+  describe '#native' do
+    it 'delegates through root_element' do
       expect(locator).to receive(:native)
 
-      subject.native
+      instance.native
     end
+  end
 
-    it 'executes scripts using Capybara' do
+  describe '#execute_script' do
+    it 'delegates through Capybara' do
       expect(Capybara.current_session).to receive(:execute_script).with('JUMP!')
 
-      subject.execute_script('JUMP!')
+      instance.execute_script('JUMP!')
     end
+  end
 
-    it 'evaluates scripts using Capybara' do
+  describe '#evaluate_script' do
+    it 'delegates through Capybara' do
       expect(Capybara.current_session).to receive(:evaluate_script).with('How High?')
 
-      subject.evaluate_script('How High?')
+      instance.evaluate_script('How High?')
     end
+  end
 
-    describe '#parent_page' do
-      let(:section) { SitePrism::Section.new(page, '.locator') }
-      let(:deeply_nested_section) do
+  describe '#parent_page' do
+    let(:section) { SitePrism::Section.new(page, '.locator') }
+    let(:deeply_nested_section) do
+      SitePrism::Section.new(
         SitePrism::Section.new(
           SitePrism::Section.new(
-            SitePrism::Section.new(
-              page, '.locator-section-large'
-            ), '.locator-section-medium'
-          ), '.locator-small'
-        )
-      end
-      let(:page) { Page.new }
+            page, '.locator-section-large'
+          ), '.locator-section-medium'
+        ), '.locator-small'
+      )
+    end
+    let(:page) { Page.new }
 
-      it 'returns the parent of a section' do
-        expect(section.parent_page).to eq(page)
+    it 'returns the parent of a section' do
+      expect(section.parent_page.class).to eq(Page)
 
-        expect(section.parent_page).to be_a SitePrism::Page
-      end
+      expect(section.parent_page).to be_a SitePrism::Page
+    end
 
-      it 'returns the parent page of a deeply nested section' do
-        expect(deeply_nested_section.parent_page).to be_a SitePrism::Page
-      end
+    it 'returns the parent page of a deeply nested section' do
+      expect(deeply_nested_section.parent_page.class).to eq(Page)
+
+      expect(deeply_nested_section.parent_page).to be_a SitePrism::Page
     end
   end
 end

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -3,14 +3,14 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
-  let(:page) { APage.new }
+  subject { APage.new }
 
   class SingleSection < SitePrism::Section; end
-  class PluralSection < SitePrism::Section; end
+  class PluralSections < SitePrism::Section; end
 
   class APage < SitePrism::Page
     section  :single_section,  SingleSection, '.bob'
-    sections :plural_sections, PluralSection, '.tim'
+    sections :plural_sections, PluralSections, '.tim'
   end
 
   describe '.section' do
@@ -19,11 +19,11 @@ describe SitePrism::Page do
     end
 
     it 'should create matching object method' do
-      expect(page).to respond_to(:single_section)
+      expect(subject).to respond_to(:single_section)
     end
 
     it 'should create matching existence method' do
-      expect(page).to respond_to(:has_single_section?)
+      expect(subject).to respond_to(:has_single_section?)
     end
   end
 
@@ -33,11 +33,11 @@ describe SitePrism::Page do
     end
 
     it 'should create matching object method' do
-      expect(page).to respond_to(:plural_sections)
+      expect(subject).to respond_to(:plural_sections)
     end
 
     it 'should create a matching existence method' do
-      expect(page).to respond_to(:has_plural_sections?)
+      expect(subject).to respond_to(:has_plural_sections?)
     end
   end
 end

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -3,12 +3,12 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
-  subject { APage.new }
+  subject { Page.new }
 
   class SingleSection < SitePrism::Section; end
   class PluralSections < SitePrism::Section; end
 
-  class APage < SitePrism::Page
+  class Page < SitePrism::Page
     section  :single_section,  SingleSection, '.bob'
     sections :plural_sections, PluralSections, '.tim'
   end
@@ -18,13 +18,8 @@ describe SitePrism::Page do
       expect(SitePrism::Page).to respond_to(:section)
     end
 
-    it 'should create matching object method' do
-      expect(subject).to respond_to(:single_section)
-    end
-
-    it 'should create matching existence method' do
-      expect(subject).to respond_to(:has_single_section?)
-    end
+    it { is_expected.to respond_to(:single_section) }
+    it { is_expected.to respond_to(:has_single_section?) }
   end
 
   describe '.sections' do
@@ -32,12 +27,7 @@ describe SitePrism::Page do
       expect(SitePrism::Page).to respond_to(:sections)
     end
 
-    it 'should create matching object method' do
-      expect(subject).to respond_to(:plural_sections)
-    end
-
-    it 'should create a matching existence method' do
-      expect(subject).to respond_to(:has_plural_sections?)
-    end
+    it { is_expected.to respond_to(:plural_sections) }
+    it { is_expected.to respond_to(:has_plural_sections?) }
   end
 end


### PR DESCRIPTION
This PR cleans up the `section_spec.rb` into the correc format as well as exposing a new public method which essentially just wraps `#native` when inside a section. This was a request from a while back just to be rehonoured.

I anticipate some refactoring required around the object_double which I've not used before and I'm sure there's a more elegant way to spoof a `Capybara::Node::Element` than the way I've done it.

ping @tgaff @TheMetalCode 