### PR TITLE
Dev Dep Bump - Take 2

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2016, Nathaniel Ritmeyer
+Copyright (c) 2011-2018, Nathaniel Ritmeyer
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -15,12 +15,10 @@ Feature: Page element interaction
     When I navigate to the home page
     Then the page does not have element
 
-  Scenario: Get individual elements
+  Scenario: Get an individual element
     When I navigate to the home page
     Then I can see the welcome header
-    # And I can see the welcome header with capybara query options - This needs moving out
     And I can see the welcome message
-    # And I can see the welcome message with capybara query options - Again this needs moving out into a plural test
     And I can see the go button
     And I can see the link to the search page
     But I cannot see the missing squirrel
@@ -29,6 +27,9 @@ Feature: Page element interaction
   Scenario: Get individual elements with query options
     When I navigate to the home page
     Then the welcome header is not matched with invalid text
+    And I can see a message using capybara query options
+    And I can see a header using capybara query options
+    And I can see a row using capybara query options
 
   Scenario: Wait for element
     When I navigate to the home page

--- a/features/page_element_interaction.feature
+++ b/features/page_element_interaction.feature
@@ -18,9 +18,9 @@ Feature: Page element interaction
   Scenario: Get individual elements
     When I navigate to the home page
     Then I can see the welcome header
-    And I can see the welcome header with capybara query options
+    # And I can see the welcome header with capybara query options - This needs moving out
     And I can see the welcome message
-    And I can see the welcome message with capybara query options
+    # And I can see the welcome message with capybara query options - Again this needs moving out into a plural test
     And I can see the go button
     And I can see the link to the search page
     But I cannot see the missing squirrel

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -48,6 +48,7 @@ end
 
 Then(/^I can see the go button$/) do
   expect(@test_site.home).to have_go_button
+
   @test_site.home.go_button.click
 end
 

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -26,10 +26,12 @@ Then(/^I can see the welcome header$/) do
   expect(@test_site.home.welcome_header.text).to eq('Welcome')
 end
 
-Then(/^I can see the welcome header with capybara query options$/) do
-  expect(@test_site.home).to have_welcome_header(text: 'Welcome')
+Then(/^I can see a header using capybara query options$/) do
+  expect(@test_site.home).to have_welcome_headers(text: 'Sub-Heading 2')
+end
 
-  expect { @test_site.home.welcome_header text: 'Welcome' }.not_to raise_error
+Then(/^I can see a row using capybara query options$/) do
+  expect(@test_site.home).to have_rows(class: 'link_c')
 end
 
 Then(/^the welcome header is not matched with invalid text$/) do
@@ -42,8 +44,8 @@ Then(/^I can see the welcome message$/) do
   expect(@test_site.home.welcome_message.text).to eq('This is the home page, there is some stuff on it')
 end
 
-Then(/^I can see the welcome message with capybara query options$/) do
-  expect(@test_site.home).to have_welcome_message(text: 'This is the home page, there is some stuff on it')
+Then(/^I can see a message using capybara query options$/) do
+  expect(@test_site.home).to have_welcome_messages(text: 'This is the home page, there is some stuff on it')
 end
 
 Then(/^I can see the go button$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,9 +37,6 @@ Capybara.configure do |config|
   config.javascript_driver = :selenium
   config.default_max_wait_time = 5
   config.app_host = 'file://' + File.dirname(__FILE__) + '/../../test_site/html'
-
-  # capybara 2.1 config options
-  config.match = :prefer_exact
   config.ignore_hidden_elements = false
 end
 

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -30,6 +30,7 @@
   </head>
   <body>
     <h1>Welcome</h1>
+    <h3>Sub-Heading 1</h3><h3>Sub-Heading 2</h3><h3>Sub-Heading 3</h3>
     <span class='welcome'>This is the home page, there is some stuff on it</span>
     <p>
       <input type='button' value='Go!'/>
@@ -39,9 +40,9 @@
     </p>
     <table>
       <tr>
-        <td><a href='a.htm'>a</a></td>
-        <td><a href='b.htm'>b</a></td>
-        <td><a href='c.htm'>c</a></td>
+        <td class="link_a"><a href='a.htm'>a</a></td>
+        <td class="link_b"><a href='b.htm'>b</a></td>
+        <td class="link_c"><a href='c.htm'>c</a></td>
       </tr>
     </table>
 
@@ -60,9 +61,7 @@
       </div>
     </div>
 
-    <p id='dumping_ground'>
-
-    </p>
+    <p id='dumping_ground'></p>
 
     <input type='submit' id='will_become_visible' value='Will become visible' style='display: none;'/>
     <input type='submit' id='will_become_invisible' value='Will become invisible' style='display: block;'/>

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -46,7 +46,7 @@
     </table>
 
     <article class='people'>
-      <h1>People</h1>
+      <h2>People</h2>
       <span class='person'>person 1</span>
       <span class='person'>person 2</span>
       <span class='person'>person 3</span>

--- a/test_site/html/page_with_people.htm
+++ b/test_site/html/page_with_people.htm
@@ -4,7 +4,7 @@
 	</head>
 	<body>
 		<article class='people-something'>
-			<h1>People</h1>
+			<h2>People</h2>
 			<span class='person'>person 1</span>
 			<span class='person'>person 2</span>
 			<span class='person'>person 3</span>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -18,6 +18,9 @@ class TestHomePage < SitePrism::Page
   # elements groups
   elements :lots_of_links, :xpath, '//td//a'
   elements :nonexistent_elements, 'input#nonexistent'
+  elements :welcome_headers, :xpath, '//h3'
+  elements :welcome_messages, :xpath, '//span'
+  elements :rows, 'td'
 
   # elements that should not exist
   element :squirrel, 'squirrel.nutz'

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -6,9 +6,9 @@ class TestHomePage < SitePrism::Page
 
   # individual elements
   element :welcome_header, :xpath, '//h1'
-  element :welcome_message, :xpath, '//span'
-  element :go_button, :xpath, '//input'
-  element :link_to_search_page, :xpath, '//a'
+  element :welcome_message, 'body > span'
+  element :go_button, '[value="Go!"]'
+  element :link_to_search_page, :xpath, '//p[2]/a'
   element :some_slow_element, :xpath, '//a[@class="slow"]'
   element :invisible_element, 'input.invisible'
   element :shy_element, 'input#will_become_visible'

--- a/test_site/sections/people.rb
+++ b/test_site/sections/people.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class People < SitePrism::Section
-  element :headline, 'h1'
+  element :headline, 'h2'
   element :dinosaur, '.dinosaur' # doesn't exist on the page
 
   elements :individuals, '.person'


### PR DESCRIPTION
Primary reason is to remove `config.match = :prefer_exact` - However in doing so I had to fix some styling on some of the test page's. Nothing major.

Added in a couple more tests and moved some items around. All fairly self explanatory - This allows all of the integration tests to pass and fail correctly instead of masking invalid selector errors.