### PR TITLE
New Feature: Add support for waiting for non-existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,19 @@ end
 @home.wait_for_search_field(10) #will wait for 10 seconds for the search field to appear
 ```
 
+#### Waiting for an element to not exist on a page
+
+Another method added by calling `element` is the `wait_for_no_<element_name>` method.
+Calling the method will cause the test to wait for the Capybara's
+default wait time for the element to not exist. It is also possible to use a
+custom amount of time to wait. Using the same example as above:
+
+```ruby
+@home.wait_for_no_search_field
+# or...
+@home.wait_for_no_search_field(10) #will wait for 10 seconds for the search field to disappear
+```
+
 #### Waiting for an element to become visible
 
 Another method added by calling `element` is the
@@ -565,6 +578,8 @@ end
 @home.has_no_search_field?
 @home.wait_for_search_field
 @home.wait_for_search_field(10)
+@home.wait_for_no_search_field
+@home.wait_for_no_search_field(10)
 @home.wait_until_search_field_visible
 @home.wait_until_search_field_visible(10)
 @home.wait_until_search_field_invisible
@@ -657,10 +672,12 @@ end
 #### Waiting for the element collection
 
 Just like for an individual element, the tests can be told to wait for
-the existence of the element collection. The `elements` method adds a
-`wait_for_<element collection name>` method that will wait for
+the existence or non-existence of the element collection. The `elements`
+method adds `wait_for_<element collection name>` and
+`wait_for_no_<element collection name>` methods that will wait for
 Capybara's default wait time until at least 1 element is found that
-matches the selector. For example, with the following page:
+matches the selector, or no elements are found that match the selector,
+respectively. For example, with the following page:
 
 ```ruby
 class Friends < SitePrism::Page
@@ -675,11 +692,18 @@ end
 @friends_page.wait_for_names
 ```
 
+or wait for the non-existence of a list of names like this:
+
+```ruby
+@friends_page.wait_for_no_names
+```
+
 Again, you can customise the wait time by supplying a number of seconds
 to wait for:
 
 ```ruby
 @friends_page.wait_for_names(10)
+@friends_page.wait_for_no_names(10)
 ```
 
 #### Waiting for the elements to be visible or invisible
@@ -997,10 +1021,11 @@ expect(@home).not_to have_menu
 
 #### Waiting for a section to exist
 
-Another method added to the page or section by the `section` method is
-`wait_for_<section name>`. Similar to what `element` does, this method
-waits for the section to appear - the test will wait up to capybara's
-default wait time until the root node of the element exists on the
+Additional methods added to the page or section by the `section` method are
+`wait_for_<section name>` and `wait_for_no_<section name>`. Similar to what
+`element` does, these methods wait for the section to appear or disappear,
+respectively - the test will wait up to capybara's
+default wait time until the root node of the element exists or does not exist on the
 page/section that our section was added to. Given the following setup:
 
 ```ruby
@@ -1020,6 +1045,13 @@ end
 ```ruby
 @home.wait_for_menu
 @home.wait_for_menu(10) # waits for 10 seconds instead of capybara's default timeout
+```
+
+... and we can wait for the menu section to disappear on the page like this:
+
+```ruby
+@home.wait_for_no_menu
+@home.wait_for_no_menu(10) # waits for 10 seconds instead of capybara's default timeout
 ```
 
 #### Waiting for a section to become visible or invisible
@@ -1239,10 +1271,11 @@ end
 
 #### Waiting for sections to appear
 
-The final method added by `sections` to the page/section we're adding
-our sections to is `wait_for_<sections name>`. It will wait for
-capybara's default wait time for there to be at least one instance of
-the section in the array of sections. For example:
+The last methods added by `sections` to the page/section we're adding
+our sections to are `wait_for_<sections name>` and `wait_for_no_<sections name>`.
+They will wait for capybara's default wait time for there to be at least one instance of
+the section in the array of sections or no instances of the section in the array
+of sections, respectively. For example:
 
 ```ruby
 class SearchResultSection < SitePrism::Section
@@ -1262,6 +1295,15 @@ end
 # ...
 @results_page.wait_for_search_results
 @results_page.wait_for_search_results(10) #=> waits for 10 seconds instead of the default capybara timeout
+```
+
+... and how to wait for the sections to disappear
+
+```ruby
+@results_page = SearchResults.new
+# ...
+@results_page.wait_for_no_search_results
+@results_page.wait_for_no_search_results(10) #=> waits for 10 seconds instead of the default capybara timeout
 ```
 
 ## Load Validations
@@ -1473,7 +1515,8 @@ The following element methods allow Capybara options to be passed as arguments t
 @results_page.<element_or_section_name> :text => "Welcome!"
 @results_page.has_<element_or_section_name>? :count => 25
 @results_page.has_no_<element_or_section_name>? :text => "Logout"
-@results_page.wait_for_<element_or_section_name> :count => 25
+@results_page.wait_for_<element_or_section_name> nil, :count => 25
+@results_page.wait_for_no_<element_or_section_name> nil, :count => 25
 @results_page.wait_until_<element_or_section_name>_visible :text => "Some ajaxy text appears!"
 @results_page.wait_until_<element_or_section_name>_invisible :text => "Some ajaxy text disappears!"
 ```
@@ -1563,12 +1606,14 @@ expect(@page).to have_my_iframe
 ### Waiting for an iframe
 
 Like an element or section, it is possible to wait for an iframe to
-exist by using the `wait_for_<iframe_name>` method. For example:
+exist or not exist by using the `wait_for_<iframe_name>` and
+`wait_for_no_<iframe_name>` methods. For example:
 
 ```ruby
 @page = PageContainingIframe.new
 # ...
 @page.wait_for_my_iframe
+@page.wait_for_no_my_iframe
 ```
 
 ### Interacting with an iframe's contents:

--- a/README.md
+++ b/README.md
@@ -1025,8 +1025,8 @@ Additional methods added to the page or section by the `section` method are
 `wait_for_<section name>` and `wait_for_no_<section name>`. Similar to what
 `element` does, these methods wait for the section to appear or disappear,
 respectively - the test will wait up to capybara's
-default wait time until the root node of the element exists or does not exist on the
-page/section that our section was added to. Given the following setup:
+default wait time until the `root_element` of the section exists or does
+not exist on the page/section that our section was added to. Given the following setup:
 
 ```ruby
 class MenuSection < SitePrism::Section

--- a/features/elements.feature
+++ b/features/elements.feature
@@ -18,3 +18,7 @@ Feature: Interaction with groups of elements
   Scenario: Waiting on a set of elements
     When I wait a variable time for elements to appear
     Then I can wait a variable time and pass specific parameters
+
+  Scenario: Waiting on a set of elements to disappear
+    When I wait a variable time for elements to disappear
+    Then I can wait a variable time for elements to disappear and pass specific parameters

--- a/features/section.feature
+++ b/features/section.feature
@@ -30,6 +30,11 @@ Feature: Page Sections
     When I navigate to the section experiments page
     Then I can see a collection of sections
 
+  Scenario: waiting on a collection of sections to disappear
+    When I navigate to the home page
+    And I wait for the collection of sections that takes a while to disappear
+    Then the removing collection of sections disappears
+
   Scenario: anonymous section
     When I navigate to the section experiments page
     Then I can see an anonymous section
@@ -59,6 +64,11 @@ Feature: Page Sections
     When I navigate to the section experiments page
     And I wait for the section element that takes a while to appear
     Then the slow section appears
+
+  Scenario: Wait for section to disappear
+    When I navigate to the section experiments page
+    And I wait for the section element that takes a while to disappear
+    Then the removing section disappears
 
   Scenario: Get parent belonging to section
     When I navigate to the home page

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -145,12 +145,21 @@ When(/^I wait a variable time for elements to appear$/) do
   @test_site.home.wait_for_lots_of_links(0.1)
 end
 
+When(/^I wait a variable time for elements to disappear$/) do
+  @test_site.home.wait_for_no_removing_links
+  @test_site.home.wait_for_no_removing_links(0.1)
+end
+
 Then(/^I can wait a variable time and pass specific parameters$/) do
   @test_site.home.wait_for_lots_of_links(0.1, count: 2)
   Capybara.using_wait_time 0.3 do
     # intentionally wait and pass nil to force this to cycle
     expect(@test_site.home.wait_for_lots_of_links(nil, count: 198_108_14)).to be false
   end
+end
+
+Then(/^I can wait a variable time for elements to disappear and pass specific parameters$/) do
+  @test_site.home.wait_for_no_removing_links(0.1, text: 'wibble')
 end
 
 Then(/^I can obtain the native property of an element$/) do

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -159,7 +159,7 @@ Then(/^I can wait a variable time and pass specific parameters$/) do
 end
 
 Then(/^I can wait a variable time for elements to disappear and pass specific parameters$/) do
-  @test_site.home.wait_for_no_removing_links(0.1, text: 'wibble')
+  expect(@test_site.home.wait_for_no_removing_links(0.1, text: 'wibble')).to be true
 end
 
 Then(/^I can obtain the native property of an element$/) do

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -4,22 +4,54 @@ When(/^I wait for the element that takes a while to appear$/) do
   @test_site.home.wait_for_some_slow_element
 end
 
+When(/^I wait for the element that takes a while to disappear$/) do
+  @test_site.home.wait_for_no_removing_element
+end
+
 Then(/^the slow element appears$/) do
   expect(@test_site.home).to have_some_slow_element
+end
+
+Then(/^the removing element disappears$/) do
+  expect(@test_site.home).not_to have_removing_element
 end
 
 When(/^I wait for a short amount of time for an element to appear$/) do
   @test_site.home.wait_for_some_slow_element(1)
 end
 
+When(/^I wait for a short amount of time for an element to disappear$/) do
+  @test_site.home.wait_for_no_removing_element(1)
+end
+
 Then(/^the element I am waiting for doesn't appear in time$/) do
   expect(@test_site.home).not_to have_some_slow_element
+end
+
+Then(/^the element I am waiting for doesn't disappear in time$/) do
+  expect(@test_site.home).to have_removing_element
 end
 
 When(/^I wait for the section element that takes a while to appear$/) do
   @test_site.section_experiments.parent_section.wait_for_slow_section_element
 end
 
+When(/^I wait for the section element that takes a while to disappear$/) do
+  @test_site.section_experiments.removing_parent_section.wait_for_no_removing_section_element
+end
+
 Then(/^the slow section appears$/) do
   expect(@test_site.section_experiments.parent_section).to have_slow_section_element
+end
+
+Then(/^the removing section disappears$/) do
+  expect(@test_site.section_experiments.removing_parent_section).not_to have_removing_section_element
+end
+
+When(/^I wait for the collection of sections that takes a while to disappear$/) do
+  @test_site.home.wait_for_no_removing_sections
+end
+
+Then(/^the removing collection of sections disappears$/) do
+  expect(@test_site.home).not_to have_removing_sections
 end

--- a/features/waiting.feature
+++ b/features/waiting.feature
@@ -13,6 +13,16 @@ Feature: Waiting for Elements
     And I wait for a short amount of time for an element to appear
     Then the element I am waiting for doesn't appear in time
 
+  Scenario: Wait for No Element - Positive
+    When I navigate to the home page
+    And I wait for the element that takes a while to disappear
+    Then the removing element disappears
+
+  Scenario: Wait for No Element - Negative
+    When I navigate to the home page
+    And I wait for a short amount of time for an element to disappear
+    Then the element I am waiting for doesn't disappear in time
+
   Scenario: Wait for Visibility of element - Default Timeout
     When I navigate to the home page
     And I wait until a particular element is visible

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -52,9 +52,7 @@ module SitePrism
       element_find_args = deduce_iframe_element_find_args(args)
       scope_find_args = deduce_iframe_scope_find_args(args)
       add_to_mapped_items(iframe_name)
-      create_existence_checker(iframe_name, *element_find_args)
-      create_nonexistence_checker(iframe_name, *element_find_args)
-      create_waiter(iframe_name, *element_find_args)
+      add_iframe_helper_methods(iframe_name, *element_find_args)
       define_method(iframe_name) do |&block|
         within_frame(*scope_find_args) do
           block.call iframe_page_class.new
@@ -89,8 +87,16 @@ module SitePrism
       create_existence_checker(name, *find_args)
       create_nonexistence_checker(name, *find_args)
       create_waiter(name, *find_args)
+      create_nonexistence_waiter(name, *find_args)
       create_visibility_waiter(name, *find_args)
       create_invisibility_waiter(name, *find_args)
+    end
+
+    def add_iframe_helper_methods(name, *find_args)
+      create_existence_checker(name, *find_args)
+      create_nonexistence_checker(name, *find_args)
+      create_waiter(name, *find_args)
+      create_nonexistence_waiter(name, *find_args)
     end
 
     def create_helper_method(proposed_method_name, *find_args)
@@ -132,6 +138,18 @@ module SitePrism
           timeout = timeout.nil? ? Capybara.default_max_wait_time : timeout
           Capybara.using_wait_time(timeout) do
             element_exists?(*find_args, *runtime_args)
+          end
+        end
+      end
+    end
+
+    def create_nonexistence_waiter(element_name, *find_args)
+      method_name = "wait_for_no_#{element_name}"
+      create_helper_method(method_name, *find_args) do
+        define_method(method_name) do |timeout = nil, *runtime_args|
+          timeout = timeout.nil? ? Waiter.default_wait_time : timeout
+          Capybara.using_wait_time(timeout) do
+            element_does_not_exist?(*find_args, *runtime_args)
           end
         end
       end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -3,48 +3,38 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
+  class PageWithElement < SitePrism::Page
+    element :bob, 'a.b c.d'
+  end
+
+  let(:page) { PageWithElement.new }
+
   it 'should respond to element' do
-    expect(SitePrism::Page).to respond_to :element
+    expect(SitePrism::Page).to respond_to(:element)
   end
 
   it 'element method should generate existence check method' do
-    class PageWithElement < SitePrism::Page
-      element :bob, 'a.b c.d'
-    end
-    page = PageWithElement.new
-    expect(page).to respond_to :has_bob?
+    expect(page).to respond_to(:has_bob?)
   end
 
   it 'element method should generate method to return the element' do
-    class PageWithElement < SitePrism::Page
-      element :bob, 'a.b c.d'
-    end
-    page = PageWithElement.new
-    expect(page).to respond_to :bob
+    expect(page).to respond_to(:bob)
   end
 
-  it 'element method without css should generate existence check method' do
-    class PageWithElement < SitePrism::Page
-      element :thing, 'input#nonexistent'
-    end
-    page = PageWithElement.new
-    expect(page).to respond_to :has_no_thing?
-  end
-
-  it 'should be able to wait for an element' do
-    class PageWithElement < SitePrism::Page
-      element :some_slow_element, 'a.slow'
-    end
-    page = PageWithElement.new
-    expect(page).to respond_to :wait_for_some_slow_element
+  it 'element method should generate non-existence check method' do
+    expect(page).to respond_to(:has_no_bob?)
   end
 
   it 'should know if all mapped elements are on the page' do
-    class PageWithAFewElements < SitePrism::Page
-      element :bob, 'a.b c.d'
-    end
-    page = PageWithAFewElements.new
-    expect(page).to respond_to :all_there?
+    expect(page).to respond_to(:all_there?)
+  end
+
+  it 'should be able to wait for an element' do
+    expect(page).to respond_to(:wait_for_bob)
+  end
+
+  it 'should be able to wait for an element to not exist' do
+    expect(page).to respond_to(:wait_for_no_bob)
   end
 
   describe '#expected_elements' do
@@ -69,39 +59,35 @@ describe SitePrism::Page do
     it 'checks only the expected elements' do
       page.all_there?
       expect(page).to have_received(:has_bob?).at_least(:once)
-      expect(page).to_not have_received(:has_success_msg?)
+      expect(page).not_to have_received(:has_success_msg?)
     end
   end
 
-  it 'element method with xpath should generate existence check method' do
+  context 'with xpath selector' do
     class PageWithElement < SitePrism::Page
       element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
     end
-    page = PageWithElement.new
-    expect(page).to respond_to :has_bob?
-  end
 
-  it 'element method with xpath should generate method to return the element' do
-    class PageWithElement < SitePrism::Page
-      element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
-    end
-    page = PageWithElement.new
-    expect(page).to respond_to :bob
-  end
+    let(:page) { PageWithElement.new }
 
-  it 'should be able to wait for an element defined with xpath selector' do
-    class PageWithElement < SitePrism::Page
-      element :some_slow_element, :xpath, '//a[@class="slow"]'
+    it 'element method should generate existence check method' do
+      expect(page).to respond_to(:has_bob?)
     end
-    page = PageWithElement.new
-    expect(page).to respond_to :wait_for_some_slow_element
-  end
 
-  it 'should know if all mapped elements defined by xpath selector are on the page' do
-    class PageWithAFewElements < SitePrism::Page
-      element :bob, :xpath, '//a[@class="b"]//c[@class="d"]'
+    it 'element method should generate method to return the element' do
+      expect(page).to respond_to(:bob)
     end
-    page = PageWithAFewElements.new
-    expect(page).to respond_to :all_there?
+
+    it 'should know if all mapped elements defined are on the page' do
+      expect(page).to respond_to(:all_there?)
+    end
+
+    it 'should be able to wait for an element' do
+      expect(page).to respond_to(:wait_for_bob)
+    end
+
+    it 'should be able to wait for an element to not exist' do
+      expect(page).to respond_to(:wait_for_no_bob)
+    end
   end
 end

--- a/spec/elements_spec.rb
+++ b/spec/elements_spec.rb
@@ -3,23 +3,21 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
+  class PageWithElements < SitePrism::Page
+    elements :bobs, 'a.b c.d'
+  end
+
+  let(:page) { PageWithElements.new }
+
   it 'should respond to elements' do
     expect(SitePrism::Page).to respond_to :elements
   end
 
   it 'elements method should generate existence check method' do
-    class PageWithElements < SitePrism::Page
-      elements :bobs, 'a.b c.d'
-    end
-    page = PageWithElements.new
     expect(page).to respond_to :has_bobs?
   end
 
   it 'elements method should generate method to return the elements' do
-    class PageWithElements < SitePrism::Page
-      elements :bobs, 'a.b c.d'
-    end
-    page = PageWithElements.new
     expect(page).to respond_to :bobs
   end
 end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -24,6 +24,8 @@
       var t1 = setTimeout("dumping_ground.appendChild(slow_link);", 2000);
       var t2 = setTimeout("document.getElementById('will_become_visible').style.display='block';", 2000);
       var t3 = setTimeout("document.getElementById('will_become_invisible').style.display='none';", 2000);
+      var t4 = setTimeout("document.getElementById('will_become_nonexistent').remove();", 2000);
+      var t5 = setTimeout("document.getElementById('link_container_will_become_nonexistent').remove();", 2000);
     }
     window.onload = load;
     </script>
@@ -64,8 +66,15 @@
       </div>
     </div>
 
+    <div id='link_container_will_become_nonexistent'>
+      <a href='a.html'>a</a>
+      <a href='b.html'>b</a>
+      <a href='c.html'>c</a>
+    </div>
+
     <p id='dumping_ground'></p>
 
+    <input type='submit' id='will_become_nonexistent' value='Will become non-existent'/>
     <input type='submit' id='will_become_visible' value='Will become visible' style='display: none;'/>
     <input type='submit' id='will_become_invisible' value='Will become invisible' style='display: block;'/>
     <input type='submit' class='invisible' value='Invisible' style='display: none;'/>

--- a/test_site/html/section_experiments.htm
+++ b/test_site/html/section_experiments.htm
@@ -17,6 +17,7 @@
       dumping_ground = document.getElementById('dumping-ground');
       //wait for a second and then add the links
       var t1 = setTimeout("dumping_ground.appendChild(slow_link);", 2000);
+      var t2 = setTimeout("document.getElementById('removing-element').remove();", 2000);
     }
     window.onload = load;
     </script>
@@ -27,6 +28,10 @@
       <div class='child-div'>
         <span class='nice-label'>something</span>
       </div>
+    </div>
+
+    <div class='removing-parent-div'>
+      <span class='removing-element' id='removing-element'>something</span>
     </div>
 
     <div class='search-results'>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -13,10 +13,12 @@ class TestHomePage < SitePrism::Page
   element :invisible_element, 'input.invisible'
   element :shy_element, 'input#will_become_visible'
   element :retiring_element, 'input#will_become_invisible'
+  element :removing_element, 'input#will_become_nonexistent'
   element :remove_container_with_element_btn, 'input#remove_container_with_element'
 
   # elements groups
   elements :lots_of_links, :xpath, '//td//a'
+  elements :removing_links, '#link_container_will_become_nonexistent > a'
   elements :nonexistent_elements, 'input#nonexistent'
   elements :welcome_headers, :xpath, '//h3'
   elements :welcome_messages, :xpath, '//span'
@@ -27,11 +29,15 @@ class TestHomePage < SitePrism::Page
   element :other_thingy, 'other.thingy'
   element :nonexistent_element, 'input#nonexistent'
 
-  # sections
+  # individual sections
   section :people, People, '.people'
   section :container_with_element, ContainerWithElement, '#container_with_element'
   section :nonexistent_section, NoElementWithinSection, 'input#nonexistent'
+  section :removing_section, NoElementWithinSection, 'input#will_become_nonexistent'
+
+  # sections groups
   sections :nonexistent_sections, NoElementWithinSection, 'input#nonexistent'
+  sections :removing_sections, NoElementWithinSection, '#link_container_will_become_nonexistent > a'
 
   # iframes
   iframe :my_iframe, MyIframe, '#the_iframe'

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -35,7 +35,7 @@ class TestHomePage < SitePrism::Page
   section :nonexistent_section, NoElementWithinSection, 'input#nonexistent'
   section :removing_section, NoElementWithinSection, 'input#will_become_nonexistent'
 
-  # sections groups
+  # section groups
   sections :nonexistent_sections, NoElementWithinSection, 'input#nonexistent'
   sections :removing_sections, NoElementWithinSection, '#link_container_will_become_nonexistent > a'
 

--- a/test_site/pages/section_experiments.rb
+++ b/test_site/pages/section_experiments.rb
@@ -4,7 +4,7 @@ class TestSectionExperiments < SitePrism::Page
   set_url '/section_experiments.htm'
 
   section :parent_section, Parent, '.parent-div'
-
+  section :removing_parent_section, Parent, '.removing-parent-div'
   sections :search_results, SearchResult, '.search-results .search-result'
 
   section :anonymous_section, '.anonymous-section' do

--- a/test_site/sections/parent.rb
+++ b/test_site/sections/parent.rb
@@ -2,5 +2,6 @@
 
 class Parent < SitePrism::Section
   element :slow_section_element, 'a.slow'
+  element :removing_section_element, '.removing-element'
   section :child_section, Child, '.child-div'
 end


### PR DESCRIPTION
This PR adds a new feature: `wait_for_no_*` methods to allow for waiting for non-existence and to mirror the rest of the functionality available for testing existence:

```
has_*
has_no_*
wait_for_*
wait_for_no_* <-- These methods were missing, and this PR adds these methods
```

Before:
```
@home.wait_for_loading_spinners nil, count: 0
```
After:
```
@home.wait_for_no_loading_spinners
```