### PR TITLE
New Feature: option for raising exception for wait timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,37 @@ with this:
 @search_page.search_results
 ```
 
+## Raising Errors on wait_for
+
+By default, when using `wait_for_*` methods, SitePrism will not raise
+an error if an element does not appear within the timeout period and will
+simply return `false` and allow the test to continue. This is different from
+the other methods such as `wait_until_*_visible` which do raise errors.
+
+Add the following code your spec_helper file to enable errors to be
+raised immediately when a `wait_for_*` does not find the element it is
+waiting for:
+
+```ruby
+SitePrism.configure do |config|
+  config.raise_on_wait_fors = true
+end
+```
+
+This enables you to replace this:
+
+```ruby
+raise unless @search_page.wait_for_search_results
+```
+
+with this:
+
+```
+# With raise on wait_fors enabled, this will automatically raise
+# if no search results are found
+@search_page.wait_for_search_results
+```
+
 ## Using SitePrism with VCR
 
 There's a SitePrism plugin called `site_prism.vcr` that lets you use

--- a/README.md
+++ b/README.md
@@ -1689,14 +1689,15 @@ with this:
 
 ## Raising Errors on wait_for
 
-By default, when using `wait_for_*` methods, SitePrism will not raise
-an error if an element does not appear within the timeout period and will
+By default, when using `wait_for_*` and `wait_for_no_*` methods, SitePrism will not raise
+an error if an element does not appear or disappear within the timeout period and will
 simply return `false` and allow the test to continue. This is different from
 the other methods such as `wait_until_*_visible` which do raise errors.
 
 Add the following code your spec_helper file to enable errors to be
-raised immediately when a `wait_for_*` does not find the element it is
-waiting for:
+raised immediately when a `wait_for_*` method does not find the element it is
+waiting for and when a `wait_for_no_*` method continues to find an element it is
+waiting to not exist:
 
 ```ruby
 SitePrism.configure do |config|
@@ -1708,6 +1709,8 @@ This enables you to replace this:
 
 ```ruby
 raise unless @search_page.wait_for_search_results
+# or...
+raise unless @search_page.wait_for_no_search_results
 ```
 
 with this:
@@ -1716,6 +1719,8 @@ with this:
 # With raise on wait_fors enabled, this will automatically raise
 # if no search results are found
 @search_page.wait_for_search_results
+# or automatically raise if search results are still found
+@search_page.wait_for_no_search_results
 ```
 
 ## Using SitePrism with VCR

--- a/features/section.feature
+++ b/features/section.feature
@@ -60,6 +60,17 @@ Feature: Page Sections
     And I wait for the section element that takes a while to appear
     Then the slow section appears
 
+  Scenario: Wait for section - Exceptions - Positive
+    Given exceptions are configured to raise on wait_fors
+    When I navigate to the section experiments page
+    And I wait for the section element that takes a while to appear
+    Then the slow section appears
+
+  Scenario: Wait for section - Exceptions - Negative
+    Given exceptions are configured to raise on wait_fors
+    When I navigate to the section experiments page
+    Then an exception is raised when I wait for a section that won't appear
+
   Scenario: Get parent belonging to section
     When I navigate to the home page
     Then I can get access to a page through a section

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+Given(/^exceptions are configured to raise on wait_fors$/) do
+  SitePrism.raise_on_wait_fors = true
+end
+
 When(/^I wait for the element that takes a while to appear$/) do
   @test_site.home.wait_for_some_slow_element
 end
@@ -12,6 +16,12 @@ When(/^I wait for a short amount of time for an element to appear$/) do
   @test_site.home.wait_for_some_slow_element(1)
 end
 
+Then(/^an exception is raised when I wait for an element that won't appear$/) do
+  expect { @test_site.home.wait_for_some_slow_element(1) }
+    .to raise_error(SitePrism::TimeOutWaitingForExistenceError)
+    .with_message('Timed out after 1s waiting for TestHomePage#some_slow_element')
+end
+
 Then(/^the element I am waiting for doesn't appear in time$/) do
   expect(@test_site.home).not_to have_some_slow_element
 end
@@ -22,4 +32,10 @@ end
 
 Then(/^the slow section appears$/) do
   expect(@test_site.section_experiments.parent_section).to have_slow_section_element
+end
+
+Then(/^an exception is raised when I wait for a section that won't appear$/) do
+  expect { @test_site.section_experiments.parent_section.wait_for_slow_section_element(1) }
+    .to raise_error(SitePrism::TimeOutWaitingForExistenceError)
+    .with_message('Timed out after 1s waiting for Parent#slow_section_element')
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,4 @@
 Before do
+  SitePrism.raise_on_wait_fors = false
   @test_site = TestSite.new
 end

--- a/features/waiting.feature
+++ b/features/waiting.feature
@@ -13,6 +13,17 @@ Feature: Waiting for Elements
     And I wait for a short amount of time for an element to appear
     Then the element I am waiting for doesn't appear in time
 
+  Scenario: Wait for Element - Exceptions - Positive
+    Given exceptions are configured to raise on wait_fors
+    When I navigate to the home page
+    And I wait for the element that takes a while to appear
+    Then the slow element appears
+
+  Scenario: Wait for Element - Exceptions - Negative
+    Given exceptions are configured to raise on wait_fors
+    When I navigate to the home page
+    Then an exception is raised when I wait for an element that won't appear
+
   Scenario: Wait for Visibility of element - Default Timeout
     When I navigate to the home page
     And I wait until a particular element is visible

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -12,7 +12,7 @@ module SitePrism
   autoload :AddressableUrlMatcher, 'site_prism/addressable_url_matcher'
 
   class << self
-    attr_accessor :use_implicit_waits
+    attr_accessor :use_implicit_waits, :raise_on_wait_fors
 
     def configure
       yield self
@@ -20,4 +20,5 @@ module SitePrism
   end
 
   @use_implicit_waits = false
+  @raise_on_wait_fors = false
 end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -73,6 +73,13 @@ module SitePrism
       raise SitePrism::UnsupportedBlock, "#{obj.class}##{name}"
     end
 
+    def raise_wait_for_if_failed(obj, name, timeout, failed)
+      return unless SitePrism.raise_on_wait_fors && failed
+
+      raise SitePrism::TimeOutWaitingForExistenceError, \
+            "Timed out after #{timeout}s waiting for #{obj.class}##{name}"
+    end
+
     private
 
     def build(name, *find_args)
@@ -130,9 +137,11 @@ module SitePrism
       create_helper_method(method_name, *find_args) do
         define_method(method_name) do |timeout = nil, *runtime_args|
           timeout = timeout.nil? ? Capybara.default_max_wait_time : timeout
-          Capybara.using_wait_time(timeout) do
+          result = Capybara.using_wait_time(timeout) do
             element_exists?(*find_args, *runtime_args)
           end
+          self.class.raise_wait_for_if_failed(self, element_name.to_s, timeout, !result)
+          result
         end
       end
     end

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -18,6 +18,7 @@ module SitePrism
     end
   end
 
+  class TimeOutWaitingForExistenceError < StandardError; end
   class TimeOutWaitingForElementVisibility < StandardError; end
   class TimeOutWaitingForElementInvisibility < StandardError; end
 


### PR DESCRIPTION
This PR adds a new option to raise exceptions if a `wait_for_*` does not find the element waited for in the given timeout period or if a `wait_for_no_*` still finds the element it is waiting to not exist after the given timeout period. This will be off by default, but can be turned on in configuration. Raising exceptions as soon as a problem is detected is important to be able to debug when a test fails.

This was previously discussed in https://github.com/natritmeyer/site_prism/issues/80#issuecomment-48780149

Before:
```
raise WaitFailed unless wait_for_menu 10
raise WaitFailed unless wait_for_search_field 10
raise WaitFailed unless wait_for_search_results 10, count: 5

raise WaitFailed unless wait_for_no_menu 10
```

After:
```
SitePrism.raise_on_wait_fors = true

wait_for_menu 10
wait_for_search_field 10
wait_for_search_results 10, count: 5 

wait_for_no_menu 10
```