### PR TITLE
Bump cucumber to 3.0.1

### DIFF
--- a/features/step_definitions/iframe_steps.rb
+++ b/features/step_definitions/iframe_steps.rb
@@ -1,54 +1,54 @@
 # frozen_string_literal: true
 
-Then(/^I can locate the iframe by id$/) do
+Then('I can locate the iframe by id') do
   @test_site.home.wait_for_my_iframe
 
   expect(@test_site.home).to have_my_iframe
 end
 
-Then(/^I can locate the iframe by index$/) do
+Then('I can locate the iframe by index') do
   @test_site.home.wait_for_index_iframe
 
   expect(@test_site.home).to have_index_iframe
 end
 
-Then(/^I can locate the iframe by name$/) do
+Then('I can locate the iframe by name') do
   @test_site.home.wait_for_named_iframe
 
   expect(@test_site.home).to have_named_iframe
 end
 
-Then(/^I can locate the iframe by xpath$/) do
+Then('I can locate the iframe by xpath') do
   @test_site.home.wait_for_xpath_iframe
 
   expect(@test_site.home).to have_xpath_iframe
 end
 
-Then(/^I can see elements in an iframe$/) do
+Then('I can see elements in an iframe') do
   @test_site.home.my_iframe do |f|
     expect(f.some_text.text).to eq('Some text in an iframe')
   end
 end
 
-Then(/^I can see elements in an indexed iframe$/) do
+Then('I can see elements in an indexed iframe') do
   @test_site.home.index_iframe do |f|
     expect(f.some_text.text).to eq('Some text in an iframe')
   end
 end
 
-Then(/^I can see elements in a named iframe$/) do
+Then('I can see elements in a named iframe') do
   @test_site.home.named_iframe do |f|
     expect(f.some_text.text).to eq('Some text in an iframe')
   end
 end
 
-Then(/^I can see elements in an xpath iframe$/) do
+Then('I can see elements in an xpath iframe') do
   @test_site.home.xpath_iframe do |f|
     expect(f.some_text.text).to eq('Some text in an iframe')
   end
 end
 
-Then(/^I can see elements in an iframe with capybara query options$/) do
+Then('I can see elements in an iframe with capybara query options') do
   @test_site.home.my_iframe do |f|
     expect(f).to have_some_text(text: 'Some text in an iframe')
   end

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -1,57 +1,57 @@
 # frozen_string_literal: true
 
-When(/^I navigate to the home page$/) do
+When('I navigate to the home page') do
   @test_site.home.load
 end
 
-When(/^I navigate to the home page that contains expected elements$/) do
+When('I navigate to the home page that contains expected elements') do
   @test_site.home_with_expected_elements.load
 end
 
-When(/^I navigate to the letter A page$/) do
+When('I navigate to the letter A page') do
   @test_site.dynamic_page.load(letter: 'a')
 end
 
-When(/^I navigate to the redirect page$/) do
+When('I navigate to the redirect page') do
   @test_site.redirect_page.load
 end
 
-When(/^I navigate to a page with no title$/) do
+When('I navigate to a page with no title') do
   @test_site.no_title.load
 end
 
-When(/^I navigate to the people page$/) do
+When('I navigate to the people page') do
   @test_site.page_with_people.load
 end
 
-When(/^I navigate to the section experiments page$/) do
+When('I navigate to the section experiments page') do
   @test_site.section_experiments.load
 end
 
-Then(/^I am on the home page$/) do
+Then('I am on the home page') do
   expect(@test_site.home).to be_displayed
 end
 
-Then(/^I am on a dynamic page$/) do
+Then('I am on a dynamic page') do
   expect(@test_site.dynamic_page).to be_displayed
 end
 
-Then(/^I am on the redirect page$/) do
+Then('I am on the redirect page') do
   expect(@test_site.redirect_page).to be_displayed
 end
 
-Then(/^I am not on the redirect page$/) do
+Then('I am not on the redirect page') do
   expect(@test_site.redirect_page).not_to be_displayed
 end
 
-Then(/^I will be redirected to the home page$/) do
+Then('I will be redirected to the home page') do
   expect(@test_site.home).to be_displayed
 end
 
-Then(/^I will be redirected to the page without a title$/) do
+Then('I will be redirected to the page without a title') do
   expect(@test_site.no_title).to be_displayed
 end
 
-When(/^I click the go button$/) do
+When('I click the go button') do
   @test_site.home.go_button.click
 end

--- a/features/step_definitions/page_element_interaction_steps.rb
+++ b/features/step_definitions/page_element_interaction_steps.rb
@@ -1,78 +1,74 @@
 # frozen_string_literal: true
 
-Then(/^the page does not have element$/) do
+Then('the page does not have element') do
   expect(@test_site.home.has_no_nonexistent_element?).to be true
 
   expect(@test_site.home).to have_no_nonexistent_element
 end
 
-Then(/^the page does not have a group of elements$/) do
+Then('the page does not have a group of elements') do
   expect(@test_site.home.has_no_nonexistent_elements?).to be true
 
   expect(@test_site.home).to have_no_nonexistent_elements
 end
 
-Then(/^I can see the welcome header$/) do
+Then('I can see the welcome header') do
   expect(@test_site.home).to have_welcome_header
 
   expect(@test_site.home.welcome_header.text).to eq('Welcome')
 end
 
-Then(/^I can see a header using a capybara text query$/) do
+Then('I can see a header using a capybara text query') do
   expect(@test_site.home).to have_welcome_headers(text: 'Sub-Heading 2')
 end
 
-Then(/^I can see a row using a capybara class query$/) do
+Then('I can see a row using a capybara class query') do
   expect(@test_site.home).to have_rows(class: 'link_c')
 end
 
-Then(/^I can see the first row$/) do
+Then('I can see the first row') do
   expect(@test_site.home).to have_rows
 
   expect(@test_site.home.rows.first.text).to eq('a')
 end
 
-Then(/^the welcome header is not matched with invalid text$/) do
+Then('the welcome header is not matched with invalid text') do
   expect(@test_site.home).to have_no_welcome_header(text: "This Doesn't Match!")
 end
 
-Then(/^I can see the welcome message$/) do
+Then('I can see the welcome message') do
   expect(@test_site.home).to have_welcome_message
 
   expect(@test_site.home.welcome_message.text).to eq('This is the home page, there is some stuff on it')
 end
 
-Then(/^I can see a message using a capybara text query$/) do
+Then('I can see a message using a capybara text query') do
   expect(@test_site.home).to have_welcome_messages(text: 'This is the home page, there is some stuff on it')
 end
 
-Then(/^I can see the go button$/) do
-  expect(@test_site.home).to have_go_button
-end
-
-Then(/^I can see the the HREF of the link$/) do
+Then('I can see the the HREF of the link') do
   expect(@test_site.home).to have_link_to_search_page
 
   expect(@test_site.home.link_to_search_page['href']).to include('search.htm')
 end
 
-Then(/^I can see the CLASS of the link$/) do
+Then('I can see the CLASS of the link') do
   expect(@test_site.home.link_to_search_page['class']).to eq('link link--undefined')
 end
 
-Then(/^I can get the text values for the group of links$/) do
+Then('I can get the text values for the group of links') do
   expect(@test_site.home.lots_of_links.map(&:text)).to eq(%w[a b c])
 end
 
-Then(/^not all expected elements are present$/) do
+Then('not all expected elements are present') do
   expect(@test_site.home).not_to be_all_there
 end
 
-Then(/^all elements marked as expected are present$/) do
+Then('all elements marked as expected are present') do
   expect(@test_site.home_with_expected_elements).to be_all_there
 end
 
-Then(/^an exception is raised when I try to deal with an element with no selector$/) do
+Then('an exception is raised when I try to deal with an element with no selector') do
   expect { @test_site.no_title.has_element_without_selector? }
     .to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.element_without_selector }
@@ -81,7 +77,7 @@ Then(/^an exception is raised when I try to deal with an element with no selecto
     .to raise_error(SitePrism::NoSelectorForElement)
 end
 
-Then(/^an exception is raised when I try to deal with elements with no selector$/) do
+Then('an exception is raised when I try to deal with elements with no selector') do
   expect { @test_site.no_title.has_elements_without_selector? }
     .to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.elements_without_selector }
@@ -90,82 +86,82 @@ Then(/^an exception is raised when I try to deal with elements with no selector$
     .to raise_error(SitePrism::NoSelectorForElement)
 end
 
-When(/^I wait until a particular element is visible$/) do
+When('I wait until a particular element is visible') do
   @test_site.home.wait_until_some_slow_element_visible
 end
 
-When(/^I wait for a specific amount of time until a particular element is visible$/) do
+When('I wait for a specific amount of time until a particular element is visible') do
   @test_site.home.wait_until_shy_element_visible(5)
 end
 
-Then(/^the previously invisible element is visible$/) do
+Then('the previously invisible element is visible') do
   expect(@test_site.home).to have_shy_element
 end
 
-Then(/^I get a timeout error when I wait for an element that never appears$/) do
+Then('I get a timeout error when I wait for an element that never appears') do
   expect { @test_site.home.wait_until_invisible_element_visible(1) }
     .to raise_error(SitePrism::TimeOutWaitingForElementVisibility)
 end
 
-When(/^I wait for an element to become invisible$/) do
+When('I wait for an element to become invisible') do
   @test_site.home.wait_until_retiring_element_invisible
 end
 
-Then(/^the previously visible element is invisible$/) do
+Then('the previously visible element is invisible') do
   expect(@test_site.home.retiring_element).not_to be_visible
 end
 
-When(/^I wait for a specific amount of time until a particular element is invisible$/) do
+When('I wait for a specific amount of time until a particular element is invisible') do
   @test_site.home.wait_until_retiring_element_invisible(5)
 end
 
-Then(/^I get a timeout error when I wait for an element that never disappears$/) do
+Then('I get a timeout error when I wait for an element that never disappears') do
   expect { @test_site.home.wait_until_welcome_header_invisible(1) }
     .to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
 end
 
-Then(/^I do not wait for an nonexistent element when checking for invisibility$/) do
+Then('I do not wait for an nonexistent element when checking for invisibility') do
   start = Time.new
   @test_site.home.wait_until_nonexistent_element_invisible(10)
 
   expect(Time.new - start).to be < 1
 end
 
-When(/^I remove the parent section of the element$/) do
+When('I remove the parent section of the element') do
   @test_site.home.remove_container_with_element_btn.click
 end
 
-Then(/^I receive an error when a section with the element I am waiting for is removed$/) do
+Then('I receive an error when a section with the element I am waiting for is removed') do
   expect { @test_site.home.container_with_element.wait_until_embedded_element_invisible }
     .to raise_error(Capybara::ElementNotFound)
 end
 
-When(/^I wait a variable time for elements to appear$/) do
+When('I wait a variable time for elements to appear') do
   @test_site.home.wait_for_lots_of_links
   @test_site.home.wait_for_lots_of_links(0.1)
 end
 
-When(/^I wait a variable time for elements to disappear$/) do
+When('I wait a variable time for elements to disappear') do
   @test_site.home.wait_for_no_removing_links
   @test_site.home.wait_for_no_removing_links(0.1)
 end
 
-Then(/^I can wait a variable time and pass specific parameters$/) do
+Then('I can wait a variable time and pass specific parameters') do
   @test_site.home.wait_for_lots_of_links(0.1, count: 2)
-  Capybara.using_wait_time 0.3 do
+  Capybara.using_wait_time(0.3) do
     # intentionally wait and pass nil to force this to cycle
     expect(@test_site.home.wait_for_lots_of_links(nil, count: 198_108_14)).to be false
   end
 end
 
-Then(/^I can wait a variable time for elements to disappear and pass specific parameters$/) do
+Then('I can wait a variable time for elements to disappear and pass specific parameters') do
   expect(@test_site.home.wait_for_no_removing_links(0.1, text: 'wibble')).to be true
 end
 
-Then(/^I can obtain the native property of an element$/) do
+Then('I can obtain the native property of an element') do
   expect(@test_site.home.welcome_header.native).to be_a Selenium::WebDriver::Element
 end
 
-Then(/^I can obtain the native property of a section$/) do
+Then('I can obtain the native property of a section') do
   expect(@test_site.home.people.native).to be_a Selenium::WebDriver::Element
 end

--- a/features/step_definitions/page_section_steps.rb
+++ b/features/step_definitions/page_section_steps.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-Then(/^I can see elements in the section$/) do
+Then('I can see elements in the section') do
   expect(@test_site.home).to have_people
 
   expect(@test_site.home.people).to have_headline(text: 'People')
 end
 
-Then(/^I can see a section in a section$/) do
+Then('I can see a section in a section') do
   expect(@test_site.section_experiments.parent_section.child_section).to have_nice_label(text: 'something')
 end
 
-Then(/^I can access elements within the section using a block$/) do
+Then('I can access elements within the section using a block') do
   expect(@test_site.home).to have_people
 
   @test_site.home.people do |section|
@@ -20,13 +20,13 @@ Then(/^I can access elements within the section using a block$/) do
   end
 end
 
-Then(/^I cannot access elements not in the section using a block$/) do
+Then('I cannot access elements not in the section using a block') do
   expect do
     @test_site.home.people { |section| expect(section).to have_dinosaur }
   end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 
-Then(/^access to elements is constrained to those within the section$/) do
+Then('access to elements is constrained to those within the section') do
   expect(@test_site.home).to have_css('.welcome')
 
   expect(@test_site.home.has_welcome_message?).to be true
@@ -38,17 +38,17 @@ Then(/^access to elements is constrained to those within the section$/) do
   end
 end
 
-Then(/^the page does not have a section$/) do
+Then('the page does not have a section') do
   expect(@test_site.home.has_no_nonexistent_section?).to be true
 
   expect(@test_site.home).to have_no_nonexistent_section
 end
 
-Then(/^I can see a list of people$/) do
+Then('I can see a list of people') do
   expect(@test_site.page_with_people.people_list.headline).to have_content('People')
 end
 
-Then(/^I can see a section within a section using nested blocks$/) do
+Then('I can see a section within a section using nested blocks') do
   expect(@test_site.section_experiments).to have_parent_section
 
   @test_site.section_experiments.parent_section do |parent|
@@ -60,7 +60,7 @@ Then(/^I can see a section within a section using nested blocks$/) do
   end
 end
 
-Then(/^I can see a collection of sections$/) do
+Then('I can see a collection of sections') do
   @test_site.section_experiments.search_results.each_with_index do |search_result, i|
     expect(search_result.title.text).to eq("title #{i}")
 
@@ -70,11 +70,11 @@ Then(/^I can see a collection of sections$/) do
   expect(@test_site.section_experiments.search_results.size).to eq(4)
 end
 
-Then(/^I can see an anonymous section$/) do
+Then('I can see an anonymous section') do
   expect(@test_site.section_experiments.anonymous_section.title.text).to eq('Anonymous Section')
 end
 
-Then(/^I can see a collection of anonymous sections$/) do
+Then('I can see a collection of anonymous sections') do
   @test_site.section_experiments.anonymous_sections.each_with_index do |section, index|
     expect(section.title.text).to eq("Section #{index}")
 
@@ -84,68 +84,68 @@ Then(/^I can see a collection of anonymous sections$/) do
   expect(@test_site.section_experiments.anonymous_sections.size).to eq(2)
 end
 
-Then(/^the section is visible$/) do
+Then('the section is visible') do
   expect(@test_site.home.people).to be_visible
 end
 
-Then(/^I can get at the people section root element$/) do
+Then('I can get at the people section root element') do
   expect(@test_site.home.people.root_element.class).to eq(Capybara::Node::Element)
 end
 
-Then(/^all expected elements are present in the search results$/) do
+Then('all expected elements are present in the search results') do
   expect(@test_site.section_experiments.search_results.first).to be_all_there
 end
 
-When(/^I execute some javascript to set a value$/) do
+When('I execute some javascript to set a value') do
   @test_site.section_experiments.search_results.first.cell_value = 'wibble'
 end
 
-Then(/^I can evaluate some javascript to get the value$/) do
+Then('I can evaluate some javascript to get the value') do
   expect(@test_site.section_experiments.search_results.first.cell_value).to eq('wibble')
 end
 
-Then(/^I can see individual people in the people list$/) do
+Then('I can see individual people in the people list') do
   expect(@test_site.home.people.individuals.size).to eq(4)
 
   expect(@test_site.home.people).to have_individuals(count: 4)
 end
 
-Then(/^I can get access to a page through a section$/) do
+Then('I can get access to a page through a section') do
   home = @test_site.home
 
   expect(home.people.parent).to eq(home)
 end
 
-Then(/^I can get a parent section for a child section$/) do
+Then('I can get a parent section for a child section') do
   parent_section = @test_site.section_experiments.parent_section
 
   expect(parent_section.child_section.parent).to eq(parent_section)
 end
 
-Then(/^I can get access to a page through a child section$/) do
+Then('I can get access to a page through a child section') do
   page = @test_site.section_experiments
 
   expect(page.parent_section.child_section.parent.parent).to eq(page)
 end
 
-Then(/^I can get direct access to a page through a child section$/) do
+Then('I can get direct access to a page through a child section') do
   page = @test_site.section_experiments
 
   expect(page.parent_section.child_section.parent_page).to eq(page)
 end
 
-Then(/^the page contains a section with no element$/) do
+Then('the page contains a section with no element') do
   expect(@test_site.home.people).to have_no_dinosaur
 end
 
-Then(/^the page contains a deeply nested span$/) do
+Then('the page contains a deeply nested span') do
   deeply_nested_section =
     @test_site.section_experiments.level_1[0].level_2[0].level_3[0].level_4[0].level_5[0]
 
   expect(deeply_nested_section.deep_span.text).to eq('Deep span')
 end
 
-Then(/^I can see a section's full text$/) do
+Then("I can see a section's full text") do
   expect(@test_site.home.people.text).to eq('People person 1 person 2 person 3 person 4')
 
   expect(@test_site.home.container_with_element.text).to eq('This will be removed when you click submit above')

--- a/features/step_definitions/page_steps.rb
+++ b/features/step_definitions/page_steps.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-Then(/^I can see an expected bit of the html$/) do
+Then('I can see an expected bit of the html') do
   expect(@test_site.home.html).to include('<span class="welcome">This is the home page')
 end
 
-Then(/^I can see an expected bit of text$/) do
+Then('I can see an expected bit of text') do
   expect(@test_site.home.text).to include('This is the home page, there is some stuff on it')
 end
 
-Then(/^I can see the expected url$/) do
+Then('I can see the expected url') do
   expect(@test_site.home.current_url).to include('test_site/html/home.htm')
 end
 
-Then(/^I can see that the page is not secure$/) do
+Then('I can see that the page is not secure') do
   expect(@test_site.home).not_to be_secure
 end
 
-Then(/^I can get the page title$/) do
+Then('I can get the page title') do
   expect(@test_site.home.title).to eq('Home Page')
 end
 
-Then(/^the page has no title$/) do
+Then('the page has no title') do
   expect(@test_site.no_title.title).to eq('')
 end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
-When(/^I wait for the element that takes a while to appear$/) do
+When('I wait for the element that takes a while to appear') do
   @test_site.home.wait_for_some_slow_element
 end
 
-When(/^I wait for the element that takes a while to disappear$/) do
+When('I wait for the element that takes a while to disappear') do
   @test_site.home.wait_for_no_removing_element
 end
 
-Then(/^the slow element appears$/) do
+Then('the slow element appears') do
   expect(@test_site.home).to have_some_slow_element
 end
 
-Then(/^the removing element disappears$/) do
+Then('the removing element disappears') do
   expect(@test_site.home).not_to have_removing_element
 end
 
-When(/^I wait for a short amount of time for an element to appear$/) do
+When('I wait for a short amount of time for an element to appear') do
   @test_site.home.wait_for_some_slow_element(1)
 end
 
-When(/^I wait for a short amount of time for an element to disappear$/) do
+When('I wait for a short amount of time for an element to disappear') do
   @test_site.home.wait_for_no_removing_element(1)
 end
 
-Then(/^the element I am waiting for doesn't appear in time$/) do
+Then("the element I am waiting for doesn't appear in time") do
   expect(@test_site.home).not_to have_some_slow_element
 end
 
-Then(/^the element I am waiting for doesn't disappear in time$/) do
+Then("the element I am waiting for doesn't disappear in time") do
   expect(@test_site.home).to have_removing_element
 end
 
-When(/^I wait for the section element that takes a while to appear$/) do
+When('I wait for the section element that takes a while to appear') do
   @test_site.section_experiments.parent_section.wait_for_slow_section_element
 end
 
-When(/^I wait for the section element that takes a while to disappear$/) do
+When('I wait for the section element that takes a while to disappear') do
   @test_site.section_experiments.removing_parent_section.wait_for_no_removing_section_element
 end
 
-Then(/^the slow section appears$/) do
+Then('the slow section appears') do
   expect(@test_site.section_experiments.parent_section).to have_slow_section_element
 end
 

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -5,7 +5,7 @@ require './lib/site_prism/version'
 Gem::Specification.new do |s|
   s.name        = 'site_prism'
   s.version     = SitePrism::VERSION
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
   s.platform    = Gem::Platform::RUBY
   s.license     = 'BSD3'
   s.authors     = ['Nat Ritmeyer', 'Luke Hill']
@@ -19,7 +19,7 @@ SitePrism implements the Page Object Model pattern on top of Capybara.'
   s.add_dependency 'addressable', ['~> 2.4']
   s.add_dependency 'capybara', ['~> 2.12']
 
-  s.add_development_dependency 'cucumber', ['2.4.0']
+  s.add_development_dependency 'cucumber', ['3.0.1']
   s.add_development_dependency 'rake', ['>= 11.0']
   s.add_development_dependency 'rspec', ['~> 3.3']
   s.add_development_dependency 'rubocop', ['0.50.0']


### PR DESCRIPTION
Note that this will involve a bump to our minimum ruby version requirements (Which has until now been locked at 2.0). I have opted to pick the latest version of cucumber which can be ran at Ruby 2.1, because at least this isn't as big of an upgrade.

However I don't see this as an issue given we need to be running our integration tests against Cucumber3 (It is slightly quicker). And Ruby 2.0 has been EOL for ages.

Also down the line other gem requirements have higher version dependencies, so this is in-line with the other ones.