### PR TITLE
Fix weird waiting bug - Hard to triage

### DIFF
--- a/development_setup.md
+++ b/development_setup.md
@@ -22,4 +22,3 @@ Happy Testing / Developing!
 
 Cheers,
 The SitePrism Team
-

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -148,8 +148,7 @@ module SitePrism
     def create_waiter(element_name, *find_args)
       method_name = "wait_for_#{element_name}"
       create_helper_method(method_name, *find_args) do
-        define_method(method_name) do |timeout = nil, *runtime_args|
-          timeout = timeout.nil? ? Capybara.default_max_wait_time : timeout
+        define_method(method_name) do |timeout = Capybara.default_max_wait_time, *runtime_args|
           result = Capybara.using_wait_time(timeout) do
             element_exists?(*find_args, *runtime_args)
           end
@@ -162,8 +161,7 @@ module SitePrism
     def create_nonexistence_waiter(element_name, *find_args)
       method_name = "wait_for_no_#{element_name}"
       create_helper_method(method_name, *find_args) do
-        define_method(method_name) do |timeout = nil, *runtime_args|
-          timeout = timeout.nil? ? Waiter.default_wait_time : timeout
+        define_method(method_name) do |timeout = Capybara.default_max_wait_time, *runtime_args|
           result = Capybara.using_wait_time(timeout) do
             element_does_not_exist?(*find_args, *runtime_args)
           end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -40,7 +40,8 @@ module SitePrism
 
     def displayed?(*args)
       expected_mappings = args.last.is_a?(::Hash) ? args.pop : {}
-      seconds = !args.empty? ? args.first : Waiter.default_wait_time
+      seconds = !args.empty? ? args.first : Capybara.default_max_wait_time
+
       raise SitePrism::NoUrlMatcherForPage if url_matcher.nil?
       begin
         Waiter.wait_until_true(seconds) { url_matches?(expected_mappings) }
@@ -49,7 +50,7 @@ module SitePrism
       end
     end
 
-    def url_matches(seconds = Waiter.default_wait_time)
+    def url_matches(seconds = Capybara.default_max_wait_time)
       return unless displayed?(seconds)
 
       if url_matcher.is_a?(Regexp)

--- a/lib/site_prism/waiter.rb
+++ b/lib/site_prism/waiter.rb
@@ -13,10 +13,5 @@ module SitePrism
 
       raise SitePrism::TimeoutException, wait_time
     end
-
-    def self.default_wait_time
-      warn 'default_wait_time is now deprecated. This will be removed in an upcoming release.'
-      Capybara.default_max_wait_time
-    end
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -266,6 +266,7 @@ describe SitePrism::Page do
 
     it 'matches a realistic local dev URL' do
       swap_current_url('http://localhost:3000/foo')
+
       expect(page.displayed?).to be true
     end
   end
@@ -280,39 +281,46 @@ describe SitePrism::Page do
     describe '#displayed?' do
       it 'returns true without expected_mappings provided' do
         swap_current_url('http://localhost:3000/foos/28')
+
         expect(page.displayed?).to be true
       end
 
       it 'returns true with correct expected_mappings provided' do
         swap_current_url('http://localhost:3000/foos/28')
+
         expect(page.displayed?(id: 28)).to be true
       end
 
       it 'returns false with incorrect expected_mappings provided' do
         swap_current_url('http://localhost:3000/foos/28')
+
         expect(page.displayed?(id: 17)).to be false
       end
     end
 
     it 'passes through incorrect expected_mappings from the be_displayed matcher' do
       swap_current_url('http://localhost:3000/foos/28')
-      expect(page).not_to be_displayed id: 17
+
+      expect(page).not_to be_displayed(id: 17)
     end
 
     it 'passes through correct expected_mappings from the be_displayed matcher' do
       swap_current_url('http://localhost:3000/foos/28')
-      expect(page).to be_displayed id: 28
+
+      expect(page).to be_displayed(id: 28)
     end
 
     describe '#url_matches' do
       it 'returns mappings from the current_url' do
         swap_current_url('http://localhost:3000/foos/15')
-        expect(page.url_matches).to eq 'scheme' => 'http', 'id' => '15'
+
+        expect(page.url_matches).to eq('scheme' => 'http', 'id' => '15')
       end
 
       it "returns nil if current_url doesn't match the url_matcher" do
         swap_current_url('http://localhost:3000/bars/15')
-        expect(page.url_matches).to eq nil
+
+        expect(page.url_matches).to be_nil
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ require 'sections/container_with_element'
 require 'pages/my_iframe'
 require 'pages/home'
 
+Capybara.default_max_wait_time = 0
+
 RSpec.configure do |config|
   config.default_formatter = :documentation
 end


### PR DESCRIPTION
So in essence, this PR does 2 things. It fixes this bug, but then also removes the previously deprecated code.

For some reason (Hard to determine why, and if it was affecting anyone in production), `Waiter.default_wait_time` seems to be calling the Capybara method, instead of the class method defined this repo. So what I did to remove the affliction was to rename the method to `sp_default_wait_time` and all associated calls. This then fixed the issue, however then our Spec run times shot up.

So this required fixing the `spec_helper.rb` to run with the wait times set to 0 (So the specs now run fast again). However after doing this, I noticed that the warning message was now incorrect (As such this PR will hit in `2.14` not `2.13`)

Once I fixed all that up. I noticed that because I've fixed all the calls, and the developmental / testing side works again as expected, the method had no inter-suite calls. So I've removed it, and tidied up the suite.

This now fixes the bug we were seeing, doesn't cause any adverse affects, and the only noticeable change is that we now don't have a 2nd class method in the Waiter class (Which shouldn't be used publically anyway).