### PR TITLE
[feat] Allow to set search arguments inside section class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 .bundle
 .idea
 .env
+.overcommit.yml

--- a/README.md
+++ b/README.md
@@ -804,11 +804,43 @@ SitePrism allows adding sections to sections) is to call the `section`
 method. It takes 3 arguments: the first is the name of the section as
 referred to on the page (sections that appear on multiple pages can be
 named differently). The second argument is the class of which an
-instance will be created to represent the page section, and the third
-argument is a css selector that identifies the root node of the section
+instance will be created to represent the page section, and the following
+arguments are [Capybara::Node::Finders](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Finders).
+These identify the root node of the section
 on this page (note that the css selector can be different for different
 pages as the whole point of sections is that they can appear in
 different places on different pages).
+
+If you define a section as a class and as an Anonymous section,
+you can have some handy constructs like the one below
+
+```ruby
+class People < SitePrism::Section
+  element :headline, 'h2'
+end
+
+class HomePage < SitePrism::Page
+  # section people_with_block will have headline and
+  # headline_clone elements in it
+  section :people_with_block, People do
+    element :headline_clone, 'h2'
+  end
+end
+```
+
+The 3rd argument (Locators), can be omitted if you are re-using the same locator for all
+references to the section Class. In order to do this, simply tell SitePrism that
+you want to use a default search argument.
+
+```ruby
+class People < SitePrism::Section
+  set_default_search_arguments '.people'
+end
+
+class Home < SitePrism::Page
+  section :people, People
+end
+```
 
 #### Accessing a page's section
 

--- a/features/section.feature
+++ b/features/section.feature
@@ -22,6 +22,11 @@ Feature: Page Sections
     When I navigate to the section experiments page
     Then I can see a section within a section using nested blocks
 
+  Scenario: section within a section using class & blocks
+    When I navigate to the home page
+    Then I can see elements from the parent section
+    And I can see elements from the block
+
   Scenario: section scoping
     When I navigate to the home page
     Then access to elements is constrained to those within the section

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -120,3 +120,11 @@ Then("I can see a section's full text") do
 
   expect(@test_site.home.container_with_element.text).to eq('This will be removed when you click submit above')
 end
+
+Then('I can see elements from the parent section') do
+  expect(@test_site.home.people).to have_headline
+end
+
+Then('I can see elements from the block') do
+  expect(@test_site.home.people).to have_headline_clone
+end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -11,6 +11,19 @@ module SitePrism
 
     attr_reader :root_element, :parent
 
+    def self.set_default_search_arguments(*args)
+      @default_search_arguments = args
+    end
+
+    def self.default_search_arguments
+      @default_search_arguments ||
+        (
+          superclass.respond_to?(:default_search_arguments) &&
+          superclass.default_search_arguments
+        ) ||
+        nil
+    end
+
     def initialize(parent, root_element)
       @parent = parent
       @root_element = root_element

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -7,12 +7,34 @@ describe SitePrism::Page do
 
   class PluralSections < SitePrism::Section; end
 
+  class PluralSectionsWithDefaults < SitePrism::Section
+    set_default_search_arguments :css, '.section'
+  end
+
   class Page < SitePrism::Page
-    sections :plural_sections, PluralSections, '.tim'
+    sections :plural_sections,               PluralSections, '.tim'
+    sections :plural_sections_with_defaults, PluralSectionsWithDefaults
+  end
+
+  describe '.sections' do
+    it 'should be callable' do
+      expect(SitePrism::Page).to respond_to(:sections)
+    end
   end
 
   context 'with sections `plural_sections` defined' do
     it { is_expected.to respond_to(:plural_sections) }
     it { is_expected.to respond_to(:has_plural_sections?) }
+  end
+
+  context 'when using sections with default search arguments and without search arguments' do
+    let(:search_arguments) { [:css, '.section'] }
+
+    it 'should use default arguments' do
+      expect(subject).to receive(:find_all).with(*search_arguments).and_return(%i[element1 element2])
+      expect(SitePrism::Section).to receive(:new).with(subject, :element1).ordered
+      expect(SitePrism::Section).to receive(:new).with(subject, :element2).ordered
+      subject.plural_sections_with_defaults
+    end
   end
 end

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -30,7 +30,9 @@ class TestHomePage < SitePrism::Page
   element :nonexistent_element, 'input#nonexistent'
 
   # individual sections
-  section :people, People, '.people'
+  section :people, People do
+    element :headline_clone, 'h2'
+  end
   section :container_with_element, ContainerWithElement, '#container_with_element'
   section :nonexistent_section, NoElementWithinSection, 'input#nonexistent'
   section :removing_section, NoElementWithinSection, 'input#will_become_nonexistent'

--- a/test_site/sections/people.rb
+++ b/test_site/sections/people.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class People < SitePrism::Section
+  set_default_search_arguments '.people'
+
   element :headline, 'h2'
   element :dinosaur, '.dinosaur' # doesn't exist on the page
 


### PR DESCRIPTION
Issue #85

## Changes
* Allow to provide default search arguments inside section definition
  *  If section has its own search arguments, default search arguments will be ignored
  * If section has no search arguments section class or any parent class deafult arguments will be used
* Allow to provide section class together with a block
* Update README
