### PR TITLE
Rubocop fixes

### DIFF
--- a/lib/site_prism/addressable_url_matcher.rb
+++ b/lib/site_prism/addressable_url_matcher.rb
@@ -5,11 +5,10 @@ require 'base64'
 
 module SitePrism
   class AddressableUrlMatcher
-    COMPONENT_NAMES = %i[scheme user password host port path query fragment].freeze
-    COMPONENT_PREFIXES = {
-      query: '?',
-      fragment: '#'
-    }.freeze
+    COMPONENT_NAMES = %i[scheme user password host
+                         port path query fragment ].freeze
+
+    COMPONENT_PREFIXES = { query: '?', fragment: '#' }.freeze
 
     attr_reader :pattern
 
@@ -17,7 +16,8 @@ module SitePrism
       @pattern = pattern
     end
 
-    # @return the hash of extracted mappings from parsing the provided URL according to our pattern,
+    # @return the hash of extracted mappings from
+    # parsing the provided URL according to our pattern,
     # or nil if the URL doesn't conform to the matcher template.
     def mappings(url)
       uri = Addressable::URI.parse(url)
@@ -31,15 +31,15 @@ module SitePrism
       result
     end
 
-    # Determine whether URL matches our pattern, and optionally whether the extracted mappings match
-    # a hash of expected values.  You can specify values as strings, numbers or regular expressions.
+    # Determine whether URL matches our pattern, and
+    # optionally whether the extracted mappings match
+    # a hash of expected values.  You can specify values
+    # as strings, numbers or regular expressions.
     def matches?(url, expected_mappings = {})
       actual_mappings = mappings(url)
-      if actual_mappings
-        expected_mappings.empty? || all_expected_mappings_match?(expected_mappings, actual_mappings)
-      else
-        false
-      end
+      return false unless actual_mappings
+      expected_mappings.empty? ||
+        all_expected_mappings_match?(expected_mappings, actual_mappings)
     end
 
     private
@@ -72,29 +72,30 @@ module SitePrism
           component_url = component_url.sub(substituted_value, template_value)
         end
 
-        component_templates[component] = Addressable::Template.new(component_url.to_s)
+        component_templates[component] =
+          Addressable::Template.new(component_url.to_s)
       end
     end
 
-    # Returns empty hash if the template omits the component, a set of substitutions if the
-    # provided URI component matches the template component, or nil if the match fails.
+    # Returns empty hash if the template omits the component,
+    # a set of substitutions if the
+    # provided URI component matches the template component,
+    # or nil if the match fails.
     def component_matches(component, uri)
-      extracted_mappings = {}
       component_template = component_templates[component]
-      if component_template
-        component_url = uri.public_send(component).to_s
-        extracted_mappings = component_template.extract(component_url)
-        unless extracted_mappings
-          # to support Addressable's expansion of queries
-          # ensure it's parsing the fragment as appropriate (e.g. {?params*})
-          prefix = COMPONENT_PREFIXES[component]
-          return nil unless prefix && (extracted_mappings = component_template.extract(prefix + component_url))
-        end
-      end
-      extracted_mappings
+      return {} unless component_template
+      component_url = uri.public_send(component).to_s
+      mappings = component_template.extract(component_url)
+      return mappings if mappings
+      # to support Addressable's expansion of queries
+      # ensure it's parsing the fragment as appropriate (e.g. {?params*})
+      prefix = COMPONENT_PREFIXES[component]
+      return nil unless prefix
+      component_template.extract(prefix + component_url)
     end
 
-    # Convert the pattern into an Addressable URI by substituting the template slugs with nonsense strings.
+    # Convert the pattern into an Addressable URI by substituting
+    # the template slugs with nonsense strings.
     def to_substituted_uri
       url = pattern
       substitutions.each_pair do |slug, value|
@@ -115,28 +116,34 @@ module SitePrism
     end
 
     def reverse_substitutions
-      @reverse_substitutions ||= slugs.each_with_index.reduce({}) do |memo, slug_index|
-        slug, index = slug_index
-        memo.merge(slug_prefix(slug) + substitution_value(index) => slug, substitution_value(index) => slug)
-      end
+      @reverse_substitutions ||=
+        slugs.each_with_index.reduce({}) do |memo, slug_index|
+          slug, index = slug_index
+          memo.merge(
+            slug_prefix(slug) + substitution_value(index) => slug,
+            substitution_value(index) => slug
+          )
+        end
     end
 
     def slugs
       pattern.scan(/{[^}]+}/)
     end
 
-    # If a slug begins with non-alpha characters, it may denote the start of a new component
-    # (e.g. query or fragment). We emit this prefix as part of the substituted slug
+    # If a slug begins with non-alpha characters,
+    # it may denote the start of a new component (e.g. query or fragment).
+    # We emit this prefix as part of the substituted slug
     # so that Addressable's URI parser can see it as such.
     def slug_prefix(slug)
-      matches = slug.match(/\A{([^A-Za-z]+)/)
-      matches && matches[1] || ''
+      prefix = slug.match(/\A{([^A-Za-z]+)/)
+      prefix && prefix[1] || ''
     end
 
     # Generate a repeatable 5 character uniform alphabetical nonsense string
     # to allow parsing as a URI
     def substitution_value(index)
-      Base64.urlsafe_encode64(Digest::SHA1.digest(index.to_s)).gsub(/[^A-Za-z]/, '')[0..5]
+      sha = Digest::SHA1.digest(index.to_s)
+      Base64.urlsafe_encode64(sha).gsub(/[^A-Za-z]/, '')[0..5]
     end
   end
 end

--- a/lib/site_prism/element_checker.rb
+++ b/lib/site_prism/element_checker.rb
@@ -14,7 +14,9 @@ module SitePrism
 
     def elements_to_check
       if self.class.expected_items
-        mapped_items.select { |el| self.class.expected_items.include?(el) }
+        mapped_items.select do |el|
+          self.class.expected_items.include?(el)
+        end
       else
         mapped_items
       end

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -6,7 +6,8 @@ module SitePrism
 
   class InvalidUrlMatcher < StandardError
     def message
-      'Could not automatically match your URL. Templated port numbers are unsupported.'
+      "Could not automatically match your URL. \
+Templated port numbers are unsupported."
     end
   end
 

--- a/lib/site_prism/loadable.rb
+++ b/lib/site_prism/loadable.rb
@@ -3,7 +3,8 @@
 module SitePrism
   module Loadable
     module ClassMethods
-      # The list of load_validations.  They will be executed in the order they are defined.
+      # The list of load_validations.
+      # They will be executed in the order they are defined.
       #
       # @return [Array]
       def load_validations
@@ -16,11 +17,14 @@ module SitePrism
 
       # Appends a load validation block to the page class.
       #
-      # When `loaded?` is called, these blocks are instance_eval'd against the current page
-      # instance.  This allows users to wait for specific events to occur on the page or certain elements
-      # to be loaded before performing any actions on the page.
+      # When `loaded?` is called, these blocks are instance_eval'd
+      # against the current page instance.
+      # This allows users to wait for specific events to occur on
+      # the page or certain elements to be loaded before performing
+      # any actions on the page.
       #
-      # @param block [&block] A block which returns true if the page loaded successfully, or false if it did not.
+      # @param block [&block] A block which returns true if the page
+      # loaded successfully, or false if it did not.
       def load_validation(&block)
         _load_validations << block
       end
@@ -35,25 +39,30 @@ module SitePrism
       base.extend(ClassMethods)
     end
 
-    # In certain circumstances, we cache that the page has already been confirmed to be loaded so that actions which
-    # call `loaded?` a second time do not need to perform the load_validation queries against the page a second time.
+    # In certain circumstances, we cache that the page has already
+    # been confirmed to be loaded so that actions which
+    # call `loaded?` a second time do not need to perform
+    # the load_validation queries against the page a second time.
     attr_accessor :loaded, :load_error
 
     # Executes the given block after the page is loaded.
     #
     # The loadable object instance is yielded into the block.
     #
-    # @param block [&block] The block to be executed once the page has finished loading.
+    # @param block [&block] The block to be executed once the page
+    # has finished loading.
     def when_loaded(&_block)
-      previously_loaded = loaded # Get original loaded value, in case we are nested inside another when_loaded block.
-      raise(ArgumentError, 'A block was expected, but none received.') unless block_given?
+      # Get original loaded value, in case we are nested
+      # inside another when_loaded block.
+      previously_loaded = loaded
+      message = 'A block was expected, but none received.'
+      raise ArgumentError, message unless block_given?
 
       # Within the block, cache loaded? to optimize performance.
       self.loaded = loaded?
-      unless loaded
-        message = "Failed to load because: #{load_error || 'no reason given'}"
-        raise(::SitePrism::NotLoadedError, message)
-      end
+
+      message = "Failed to load because: #{load_error || 'no reason given'}"
+      raise ::SitePrism::NotLoadedError, message unless loaded
 
       yield self
     ensure
@@ -62,7 +71,8 @@ module SitePrism
 
     # Check if the page is loaded.
     #
-    # On failure, if an error was reported by a failing validation, it will be available via the `load_error` accessor.
+    # On failure, if an error was reported by a failing validation,
+    # it will be available via the `load_error` accessor.
     #
     # @return [Boolean] True if the page loaded successfully; otherwise false.
     def loaded?
@@ -73,7 +83,8 @@ module SitePrism
       load_validations_pass?
     end
 
-    # If any load validations from page subclasses returns false, immediately return false.
+    # If any load validations from page subclasses returns false,
+    # immediately return false.
     def load_validations_pass?
       self.class.load_validations.all? do |validation|
         passed, message = instance_eval(&validation)

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -3,6 +3,7 @@
 require 'site_prism/loadable'
 
 module SitePrism
+  # rubocop:disable Metrics/ClassLength
   class Page
     include Capybara::DSL
     include ElementChecker
@@ -140,4 +141,5 @@ module SitePrism
       @addressable_url_matcher ||= AddressableUrlMatcher.new(url_matcher)
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -10,7 +10,10 @@ module SitePrism
     extend ElementContainer
 
     load_validation do
-      [displayed?, "Expected #{current_url} to match #{url_matcher} but it did not."]
+      [
+        displayed?,
+        "Expected #{current_url} to match #{url_matcher} but it did not."
+      ]
     end
 
     def page

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |s|
   s.email       = %w[nat@natontesting.com lukehill_uk@hotmail.com]
   s.homepage    = 'http://github.com/natritmeyer/site_prism'
   s.summary     = 'A Page Object Model DSL for Capybara'
-  s.description = 'SitePrism gives you a simple, clean and semantic DSL for describing your site.
-SitePrism implements the Page Object Model pattern on top of Capybara.'
+  s.description = "SitePrism gives you a simple, \
+clean and semantic DSL for describing your site.
+SitePrism implements the Page Object Model pattern on top of Capybara."
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']


### PR DESCRIPTION
Fixed line length offenses for `lib/` (except `element_container.rb` -  there are several PR changing this file)