### PR TITLE
Reduce self.class calls

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -212,7 +212,7 @@ module SitePrism
 
       def create_no_selector(method_name)
         define_method(method_name) do
-          raise SitePrism::NoSelectorForElement.new, "#{name} => :#{method_name} needs a selector"
+          raise SitePrism::NoSelectorForElement.new, "#{self.class.name} => :#{method_name} needs a selector"
         end
       end
 

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -7,7 +7,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
-    extend ElementContainer
+    include ElementContainer
 
     load_validation do
       [displayed?, "Expected #{current_url} to match #{url_matcher} but it did not."]

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -7,7 +7,7 @@ module SitePrism
     include Capybara::DSL
     include ElementChecker
     include Loadable
-    extend ElementContainer
+    include ElementContainer
 
     attr_reader :root_element, :parent
 


### PR DESCRIPTION
Currently, in `ElementsContainer` module, we have a mix of class methods (`element`, `elements`, `section` ... ) and instance methods (`merge_arguments`, `raise_*`, ...). Extending `Page` and `Section` with this module makes instance methods become class methods and they have to be called `self.class.<method_name>`.

This change does it more proper way. We **include** `ElementsContainer` into `Page` and `Section` leaving only instance methods in this module. All class methods are defined in `ClassMethods` submodule. And in `ElementsContainer` module `self.included` ruby hook method defined, telling the class, in which `ElementsContainer` is included, to extend `ClassMethods` module.