### PR TITLE
Capybara 3 rework

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   TargetRubyVersion: 2.2
+  Exclude:
+    - './spec/*_spec.rb'
 
 Documentation:
   Enabled: false
@@ -13,13 +15,9 @@ Style/SafeNavigation:
 Style/RegexpLiteral:
   Enabled: false
 
-BlockLength:
-  Exclude:
-    - './spec/*_spec.rb'
-
-# Offense count: 24
+## Offense count: 13
 Metrics/LineLength:
-  Max: 107
+  Max: 99
 
 Gemspec/RequiredRubyVersion:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ BlockLength:
   Exclude:
     - './spec/*_spec.rb'
 
-# Offense count: 18
+# Offense count: 24
 Metrics/LineLength:
   Max: 107
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 dist: trusty
 
 rvm:
-  - 2.1.10
   - 2.2.9
   - 2.3
   - 2.4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We have a brief set of setup docs [HERE](https://github.com/natritmeyer/site_pri
 
 ## Supported Rubies / Browsers
 
-SitePrism is built and tested to work on Ruby 2.1 - 2.5. There is also some limited support for Ruby 2.0.0.
+SitePrism is built and tested to work on Ruby 2.2 - 2.5. There is also some limited support for the Ruby 2.1 series.
 
 SitePrism should run on all major browsers. The gem's integration tests are ran on the latest versions of Chrome and Firefox.
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,4 @@
 - Generic spec walkthrough - (have done section/sections/element/elements/top half of page)
 - Advanced spec clean. Make sure each spec file represents the right items
 - Setup a secondary gemfile to track against older items (As and when we upgrade Ruby/Gem deps)
+- Standardise wait key assignment in element container (Work broken out from Capybara3 rework)

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,11 @@
 ### Backlog:
 -  `site_prism/addressable_url_matcher.rb` - Needs more of a spring clean
 -  `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
--  Begin to refactor `displayed?(*args)`, to remove enumerable args (Shouldn't be enumerable)
 -  Update of Ruby Version to supported version
 -  Rubocop LineLength reduction (Continue this, will be hard work, probably several PR's)
 -  Rubocop MethodLength reduction (Should be a small-er PR)
 -  Create iFrame specs (Even though private methods)
 -  Allow scoping iFrames to then be passed into element native object
 - Generic spec walkthrough - (have done section/sections/element/elements/top half of page)
+- Advanced spec clean. Make sure each spec file represents the right items
+- Setup a secondary gemfile to track against older items (As and when we upgrade Ruby/Gem deps)

--- a/features/malformed_items.feature
+++ b/features/malformed_items.feature
@@ -4,8 +4,8 @@ Feature: Malformed Items
 
   Scenario: Element without a selector
     When I navigate to a page with no title
-    Then an exception is raised when I try to deal with an element with no selector
+    Then an exception is raised when I deal with an element with no selector
 
   Scenario: Elements without a selector
     When I navigate to a page with no title
-    Then an exception is raised when I try to deal with elements with no selector
+    Then an exception is raised when I deal with elements with no selector

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -38,8 +38,9 @@ Then('I can see the welcome message') do
 end
 
 Then('I can see a message using a capybara text query') do
-  expect(@test_site.home)
-    .to(have_welcome_messages(text: 'This is the home page, there is some stuff on it'))
+  sample_text = 'This is the home page, there is some stuff on it'
+
+  expect(@test_site.home).to have_welcome_messages(text: sample_text)
 end
 
 Then('I can see the the HREF of the link') do

--- a/features/step_definitions/malformed_items_steps.rb
+++ b/features/step_definitions/malformed_items_steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Then('an exception is raised when I try to deal with an element with no selector') do
+Then('an exception is raised when I deal with an element with no selector') do
   expect { @test_site.no_title.has_element_without_selector? }
     .to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.element_without_selector }
@@ -9,7 +9,7 @@ Then('an exception is raised when I try to deal with an element with no selector
     .to raise_error(SitePrism::NoSelectorForElement)
 end
 
-Then('an exception is raised when I try to deal with elements with no selector') do
+Then('an exception is raised when I deal with elements with no selector') do
   expect { @test_site.no_title.has_elements_without_selector? }
     .to raise_error(SitePrism::NoSelectorForElement)
   expect { @test_site.no_title.elements_without_selector }

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -36,7 +36,7 @@ When('I wait for a short amount of time for an element to disappear') do
   @duration = Time.now - start_time
 end
 
-Then("an exception is raised when I wait for an element that won't appear in time") do
+Then("an exception is raised when I wait for an element that won't appear") do
   start_time = Time.now
 
   expect { @test_site.home.wait_for_some_slow_element(1) }
@@ -90,16 +90,21 @@ Then(/^the removing section disappears$/) do
     .not_to have_removing_section_element
 end
 
-Then(/^an exception is raised when I wait for a section that won't appear$/) do
-  expect { @test_site.section_experiments.parent_section.wait_for_slow_section_element(1) }
+Then("an exception is raised when I wait for a section that won't appear") do
+  section = @test_site.section_experiments.parent_section
+
+  expect { section.wait_for_slow_section_element(1) }
     .to raise_error(SitePrism::TimeOutWaitingForExistenceError)
     .with_message('Timed out after 1s waiting for Parent#slow_section_element')
 end
 
-Then(/^an exception is raised when I wait for a section that won't disappear$/) do
-  expect { @test_site.section_experiments.removing_parent_section.wait_for_no_removing_section_element(1) }
+Then("an exception is raised when I wait for a section that won't disappear") do
+  section = @test_site.section_experiments.removing_parent_section
+  error_message = 'Timed out after 1s waiting for no Parent#removing_section_element'
+
+  expect { section.wait_for_no_removing_section_element(1) }
     .to raise_error(SitePrism::TimeOutWaitingForNonExistenceError)
-    .with_message('Timed out after 1s waiting for no Parent#removing_section_element')
+    .with_message(error_message)
 end
 
 When(/^I wait for the collection of sections that takes a while to disappear$/) do

--- a/features/waiting.feature
+++ b/features/waiting.feature
@@ -24,7 +24,7 @@ Feature: Waiting for Elements
   Scenario: Wait for Element - Exceptions - Negative
     Given exceptions are configured to raise on wait_fors
     When I navigate to the home page
-    Then an exception is raised when I wait for an element that won't appear in time
+    Then an exception is raised when I wait for an element that won't appear
 
   Scenario: Wait for No Element - Positive
     When I navigate to the home page

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -46,33 +46,38 @@ module SitePrism
     module ClassMethods
       attr_reader :mapped_items, :expected_items
 
-      def element(element_name, *find_args)
-        build(element_name, *find_args) do
-          define_method(element_name.to_s) do |*runtime_args, &element_block|
-            raise_if_block(self, element_name.to_s, !element_block.nil?)
+      def element(name, *find_args)
+        build(name, *find_args) do
+          define_method(name) do |*runtime_args, &element_block|
+            raise_if_block(self, name, !element_block.nil?)
             _find(*merge_args(find_args, runtime_args))
           end
         end
       end
 
-      def elements(collection_name, *find_args)
-        build(collection_name, *find_args) do
-          define_method(collection_name.to_s) do |*runtime_args, &element_block|
-            raise_if_block(self, collection_name.to_s, !element_block.nil?)
+      def elements(name, *find_args)
+        build(name, *find_args) do
+          define_method(name) do |*runtime_args, &element_block|
+            raise_if_block(self, name, !element_block.nil?)
             _all(*merge_args(find_args, runtime_args))
           end
         end
       end
-      alias collection elements
+
+      def collection(name, *find_args)
+        warn 'Using collection is now deprecated and will be removed.'
+        warn 'Use elements DSL notation instead.'
+        elements(name, *find_args)
+      end
 
       def expected_elements(*elements)
         @expected_items = elements
       end
 
-      def section(section_name, *args, &block)
+      def section(name, *args, &block)
         section_class, find_args = extract_section_options(args, &block)
-        build(section_name, *find_args) do
-          define_method section_name do |*runtime_args, &runtime_block|
+        build(name, *find_args) do
+          define_method(name) do |*runtime_args, &runtime_block|
             section_element = _find(*merge_args(find_args, runtime_args))
             section_class.new(self, section_element, &runtime_block)
           end
@@ -83,7 +88,7 @@ module SitePrism
         section_class, find_args = extract_section_options(args, &block)
         build(name, *find_args) do
           define_method(name) do |*runtime_args, &element_block|
-            raise_if_block(self, name.to_s, !element_block.nil?)
+            raise_if_block(self, name, !element_block.nil?)
             _all(*merge_args(find_args, runtime_args)).map do |element|
               section_class.new(self, element)
             end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -32,6 +32,11 @@ module SitePrism
             "Timed out after #{timeout}s waiting for no #{obj.class}##{name}"
     end
 
+    # Sanitize method called before calling any SitePrism DSL method or
+    # meta-programmed method. This ensures that the Capybara query is correct.
+    #
+    # Accepts any combination of arguments sent at DSL definition or runtime
+    # and combines them in such a way that Capybara can operate with them.
     def merge_args(find_args, runtime_args, override_options = {})
       find_args = find_args.dup
       runtime_args = runtime_args.dup
@@ -39,6 +44,10 @@ module SitePrism
       options.merge!(find_args.pop) if find_args.last.is_a? Hash
       options.merge!(runtime_args.pop) if runtime_args.last.is_a? Hash
       options.merge!(override_options)
+      options.merge!(wait: false) unless SitePrism.use_implicit_waits
+
+      return [*find_args, *runtime_args] if options.empty?
+
       [*find_args, *runtime_args, options]
     end
 

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -50,7 +50,7 @@ module SitePrism
         build(element_name, *find_args) do
           define_method(element_name.to_s) do |*runtime_args, &element_block|
             raise_if_block(self, element_name.to_s, !element_block.nil?)
-            find_first(*merge_args(find_args, runtime_args))
+            _find(*merge_args(find_args, runtime_args))
           end
         end
       end
@@ -59,7 +59,7 @@ module SitePrism
         build(collection_name, *find_args) do
           define_method(collection_name.to_s) do |*runtime_args, &element_block|
             raise_if_block(self, collection_name.to_s, !element_block.nil?)
-            find_all(*merge_args(find_args, runtime_args))
+            _all(*merge_args(find_args, runtime_args))
           end
         end
       end
@@ -73,7 +73,7 @@ module SitePrism
         section_class, find_args = extract_section_options(args, &block)
         build(section_name, *find_args) do
           define_method section_name do |*runtime_args, &runtime_block|
-            section_element = find_first(*merge_args(find_args, runtime_args))
+            section_element = _find(*merge_args(find_args, runtime_args))
             section_class.new(self, section_element, &runtime_block)
           end
         end
@@ -84,7 +84,7 @@ module SitePrism
         build(name, *find_args) do
           define_method(name) do |*runtime_args, &element_block|
             raise_if_block(self, name.to_s, !element_block.nil?)
-            find_all(*merge_args(find_args, runtime_args)).map do |element|
+            _all(*merge_args(find_args, runtime_args)).map do |element|
               section_class.new(self, element)
             end
           end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -179,7 +179,9 @@ module SitePrism
           define_method(method_name) do |*runtime_args|
             wait_time = SitePrism.use_implicit_waits ? max_wait_time : 0
             visibility_args = { wait: wait_time }
-            element_does_not_exist?(*merge_args(find_args, runtime_args, **visibility_args))
+            element_does_not_exist?(
+              *merge_args(find_args, runtime_args, **visibility_args)
+            )
           end
         end
       end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -44,11 +44,15 @@ module SitePrism
       options.merge!(find_args.pop) if find_args.last.is_a? Hash
       options.merge!(runtime_args.pop) if runtime_args.last.is_a? Hash
       options.merge!(override_options)
-      options.merge!(wait: false) unless SitePrism.use_implicit_waits
+      options[:wait] = false unless deactivate_waiting?(options)
 
       return [*find_args, *runtime_args] if options.empty?
 
       [*find_args, *runtime_args, options]
+    end
+
+    def deactivate_waiting?(options)
+      SitePrism.use_implicit_waits || options.has_key?(:wait)
     end
 
     # rubocop:disable Metrics/ModuleLength
@@ -163,9 +167,8 @@ module SitePrism
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
             wait_time = SitePrism.use_implicit_waits ? max_wait_time : 0
-            Capybara.using_wait_time(wait_time) do
-              element_exists?(*merge_args(find_args, runtime_args))
-            end
+            visibility_args = { wait: wait_time }
+            element_exists?(*merge_args(find_args, runtime_args, **visibility_args))
           end
         end
       end
@@ -175,9 +178,8 @@ module SitePrism
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
             wait_time = SitePrism.use_implicit_waits ? max_wait_time : 0
-            Capybara.using_wait_time(wait_time) do
-              element_does_not_exist?(*merge_args(find_args, runtime_args))
-            end
+            visibility_args = { wait: wait_time }
+            element_does_not_exist?(*merge_args(find_args, runtime_args, **visibility_args))
           end
         end
       end
@@ -186,9 +188,8 @@ module SitePrism
         method_name = "wait_for_#{element_name}"
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |timeout = max_wait_time, *runtime_args|
-            result = Capybara.using_wait_time(timeout) do
-              element_exists?(*merge_args(find_args, runtime_args))
-            end
+            visibility_args = { wait: timeout }
+            result = element_exists?(*merge_args(find_args, runtime_args, **visibility_args))
             raise_wait_for_if_failed(self, element_name.to_s, timeout, !result)
             result
           end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -108,11 +108,7 @@ module SitePrism
     end
 
     def _all(*find_args)
-      if SitePrism.use_implicit_waits
-        page.all(*find_args)
-      else
-        page.all(*find_args, wait: false)
-      end
+      page.all(*find_args)
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -103,11 +103,11 @@ module SitePrism
 
     private
 
-    def find_first(*find_args)
+    def _find(*find_args)
       page.find(*find_args)
     end
 
-    def find_all(*find_args)
+    def _all(*find_args)
       page.all(*find_args)
     end
 

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -108,7 +108,11 @@ module SitePrism
     end
 
     def _all(*find_args)
-      page.all(*find_args)
+      if SitePrism.use_implicit_waits
+        page.all(*find_args)
+      else
+        page.all(*find_args, wait: false)
+      end
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -71,11 +71,11 @@ module SitePrism
     end
 
     def element_exists?(*find_args)
-      root_element.has_selector?(*find_args) unless root_element.nil?
+      page && page.has_selector?(*find_args)
     end
 
     def element_does_not_exist?(*find_args)
-      root_element.has_no_selector?(*find_args) unless root_element.nil?
+      page && page.has_no_selector?(*find_args)
     end
   end
 end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -67,11 +67,7 @@ module SitePrism
     end
 
     def _all(*find_args)
-      if SitePrism.use_implicit_waits
-        page.all(*find_args)
-      else
-        page.all(*find_args, wait: false)
-      end
+      page.all(*find_args)
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -67,7 +67,11 @@ module SitePrism
     end
 
     def _all(*find_args)
-      page.all(*find_args)
+      if SitePrism.use_implicit_waits
+        page.all(*find_args)
+      else
+        page.all(*find_args, wait: false)
+      end
     end
 
     def element_exists?(*find_args)

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -62,8 +62,12 @@ module SitePrism
 
     private
 
-    def find_first(*find_args)
-      root_element.find(*find_args)
+    def _find(*find_args)
+      page.find(*find_args)
+    end
+
+    def _all(*find_args)
+      page.all(*find_args)
     end
 
     def element_exists?(*find_args)

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -21,10 +21,10 @@ SitePrism implements the Page Object Model pattern on top of Capybara."
   s.add_dependency 'capybara', ['>= 2.14', '< 3.1']
 
   s.add_development_dependency 'cucumber', ['3.0.1']
-  s.add_development_dependency 'dotenv', ['~> 2.2']
+  s.add_development_dependency 'dotenv', ['~> 2.5']
   s.add_development_dependency 'rake', ['~> 12.0']
-  s.add_development_dependency 'rspec', ['~> 3.5']
-  s.add_development_dependency 'rubocop', ['~> 0.50']
+  s.add_development_dependency 'rspec', ['~> 3.6']
+  s.add_development_dependency 'rubocop', ['~> 0.52']
   s.add_development_dependency 'selenium-webdriver', ['~> 3.4']
   s.add_development_dependency 'simplecov', ['~> 0.14']
 end

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -18,7 +18,7 @@ SitePrism implements the Page Object Model pattern on top of Capybara."
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.4']
-  s.add_dependency 'capybara', ['~> 2.12']
+  s.add_dependency 'capybara', ['>= 2.14', '< 3.1']
 
   s.add_development_dependency 'cucumber', ['3.0.1']
   s.add_development_dependency 'dotenv', ['~> 2.2']
@@ -26,5 +26,5 @@ SitePrism implements the Page Object Model pattern on top of Capybara."
   s.add_development_dependency 'rspec', ['~> 3.5']
   s.add_development_dependency 'rubocop', ['~> 0.50']
   s.add_development_dependency 'selenium-webdriver', ['~> 3.4']
-  s.add_development_dependency 'simplecov', ['~> 0.12']
+  s.add_development_dependency 'simplecov', ['~> 0.14']
 end

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -171,9 +171,6 @@ when all load validations pass" do
       loadable.load_validation { [true, 'this cannot fail'] }
       loadable.load_validation { [false, 'fubar'] }
       inheriting_loadable.load_validation { [true, 'this also cannot fail'] }
-      inheriting_loadable.load_validation do
-        [true, 'this also also cannot fail']
-      end
 
       instance = inheriting_loadable.new
       instance.loaded?

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -400,7 +400,7 @@ from the be_displayed matcher" do
   end
 
   it 'should expose the page title' do
-    expect(SitePrism::Page.new).to respond_to :title
+    expect(SitePrism::Page.new).to respond_to(:title)
   end
 
   it 'should raise an exception if passing a block to an element' do

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -2,10 +2,11 @@
 
 require 'spec_helper'
 
-class Section < SitePrism::Section; end
-class Page < SitePrism::Page; end
-
 describe SitePrism::Page do
+
+  class Section < SitePrism::Section; end
+  class Page < SitePrism::Page; end
+
   describe '.section' do
     it 'should be callable' do
       expect(SitePrism::Page).to respond_to(:section)
@@ -27,7 +28,7 @@ describe SitePrism::Page do
       subject { PageWithSections.new }
 
       before do
-        allow(subject).to receive(:find_first).and_return(:element)
+        allow(subject).to receive(:_find).and_return(:element)
       end
 
       it 'should be an instance of provided section class' do
@@ -117,7 +118,7 @@ class or/and a block as the second argument."
         let(:search_arguments) { ['.other-section', {}] }
 
         it 'returns the search arguments for a section' do
-          expect(page).to receive(:find_first).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments)
           page.section_with_locator
         end
       end
@@ -126,7 +127,7 @@ class or/and a block as the second argument."
         let(:search_arguments) { [:css, '.section', {}] }
 
         it 'returns the default search arguments for a section' do
-          expect(page).to receive(:find_first).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments)
           page.section_using_defaults
         end
       end
@@ -136,7 +137,7 @@ parent section but without search arguments" do
         let(:search_arguments) { [:css, '.section', {}] }
 
         it 'returns the default search arguments for the parent section' do
-          expect(page).to receive(:find_first).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments)
           page.section_using_defaults_from_parent
         end
       end
@@ -267,6 +268,10 @@ search arguments if defaults are not set" do
     end
   end
 
+  it 'responds to Capybara methods' do
+    expect(section_without_block).to respond_to(*Capybara::Session::DSL_METHODS)
+  end
+
   describe '#parent_page' do
     let(:section) { SitePrism::Section.new(page, '.locator') }
     let(:deeply_nested_section) do
@@ -290,14 +295,6 @@ search arguments if defaults are not set" do
       expect(deeply_nested_section.parent_page.class).to eq(Page)
 
       expect(deeply_nested_section.parent_page).to be_a SitePrism::Page
-    end
-
-    it 'responds to #visible? method' do
-      expect(section).to respond_to(:visible?)
-    end
-
-    it 'responds to Capybara methods' do
-      expect(section).to respond_to(*Capybara::Session::DSL_METHODS)
     end
   end
 

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe SitePrism::Page do
   class Section < SitePrism::Section; end
   class Page < SitePrism::Page; end
+  let(:dont_wait) { { wait: false } }
 
   describe '.section' do
     it 'should be callable' do
@@ -117,7 +118,7 @@ class or/and a block as the second argument."
         let(:search_arguments) { ['.other-section'] }
 
         it 'returns the search arguments for a section' do
-          expect(page).to receive(:_find).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
           page.section_with_locator
         end
@@ -127,7 +128,7 @@ class or/and a block as the second argument."
         let(:search_arguments) { [:css, '.section'] }
 
         it 'returns the default search arguments for a section' do
-          expect(page).to receive(:_find).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
           page.section_using_defaults
         end
@@ -138,7 +139,7 @@ parent section but without search arguments" do
         let(:search_arguments) { [:css, '.section'] }
 
         it 'returns the default search arguments for the parent section' do
-          expect(page).to receive(:_find).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
           page.section_using_defaults_from_parent
         end
@@ -170,6 +171,7 @@ describe SitePrism::Section do
   let(:section_with_block) do
     SitePrism::Section.new(Page.new, locator) { 1 + 1 }
   end
+  let(:dont_wait) { { wait: false } }
 
   describe '#default_search_arguments' do
     class BaseSection < SitePrism::Section
@@ -240,11 +242,11 @@ search arguments if defaults are not set" do
     end
 
     context 'with Capybara query arguments' do
-      let(:query_args) { [css: '.my-css', text: 'Hi'] }
+      let(:query_args) { { css: '.my-css', text: 'Hi' } }
       let(:locator_args) { '.class-one' }
 
       it 'passes in an empty hash, which is then converted into a hash of query arguments' do
-        expect(page).to receive(:_find).with(*locator_args, *query_args)
+        expect(page).to receive(:_find).with(*locator_args, **query_args, **dont_wait)
 
         page.new_section
       end
@@ -255,7 +257,7 @@ search arguments if defaults are not set" do
       let(:locator_args) { '.class-two' }
 
       it 'passes in an empty hash, which is then sanitized out' do
-        expect(page).to receive(:_find).with(*locator_args)
+        expect(page).to receive(:_find).with(*locator_args, **dont_wait)
 
         page.new_element
       end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -3,7 +3,6 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
-
   class Section < SitePrism::Section; end
   class Page < SitePrism::Page; end
 

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -118,6 +118,7 @@ class or/and a block as the second argument."
 
         it 'returns the search arguments for a section' do
           expect(page).to receive(:_find).with(*search_arguments)
+
           page.section_with_locator
         end
       end
@@ -127,6 +128,7 @@ class or/and a block as the second argument."
 
         it 'returns the default search arguments for a section' do
           expect(page).to receive(:_find).with(*search_arguments)
+
           page.section_using_defaults
         end
       end
@@ -137,6 +139,7 @@ parent section but without search arguments" do
 
         it 'returns the default search arguments for the parent section' do
           expect(page).to receive(:_find).with(*search_arguments)
+
           page.section_using_defaults_from_parent
         end
       end
@@ -157,6 +160,8 @@ set_default_search_arguments within section class"
       end
     end
   end
+
+  it { is_expected.to respond_to(*Capybara::Session::DSL_METHODS) }
 end
 
 describe SitePrism::Section do

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -245,7 +245,7 @@ search arguments if defaults are not set" do
       let(:query_args) { { css: '.my-css', text: 'Hi' } }
       let(:locator_args) { '.class-one' }
 
-      it 'passes in an empty hash, which is then converted into a hash of query arguments' do
+      it 'passes in a hash of query arguments' do
         expect(page).to receive(:_find).with(*locator_args, **query_args, **dont_wait)
 
         page.new_section

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -34,7 +34,7 @@ and without search arguments" do
     before do
       allow(subject)
         .to receive(:_all)
-        .with(*search_arguments)
+        .with(*search_arguments, wait: false)
         .and_return(%i[element1 element2])
     end
 

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -29,7 +29,7 @@ describe SitePrism::Page do
 
   context "when using sections with default search arguments \
 and without search arguments" do
-    let(:search_arguments) { [:css, '.section', {}] }
+    let(:search_arguments) { [:css, '.section'] }
 
     before do
       allow(subject)

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -33,7 +33,7 @@ and without search arguments" do
 
     before do
       allow(subject)
-        .to receive(:find_all)
+        .to receive(:_all)
         .with(*search_arguments)
         .and_return(%i[element1 element2])
     end


### PR DESCRIPTION
Enable provisional Capybara 3 support.
- Fix up method collisions and amend specs as appropriate
- Fix newly introduced `#all` functionality (We don't call `#first`)
- Deprecate `collection` DSL definition

EDIT: Additional work that is also covered here.
- Reduced Travis test overhead by 20% (Removing Ruby 2.1 support, which in theory is impossible with Capybara3 and we shouldn't test as it's our lowest level)
- Fix up of codecoverage back up to ~100% (There are 3 lines uncalled which are the `collection` deprecation - This proves it was never actually called in our codebase internally)
- Fix up implicit waiting for all methods. This closes #243
