### PR TITLE
Add tgaff implicit wait tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1733,6 +1733,18 @@ with this:
 @search_page.search_results
 ```
 
+Note that even with implicit waits on you can temporarily modify wait times in SitePrism to help work-around special circumstances.  
+
+```rb
+# Option 1: using wait_for
+@search_page.wait_for_search_results(30) # will wait up to 30seconds
+
+# Option 2: using Capybara directly 
+Capybara.using_wait_time(30) do
+  @search_page.subsection.search_results
+end
+```
+
 ## Raising Errors on wait_for
 
 By default, when using `wait_for_*` and `wait_for_no_*` methods, SitePrism will not raise

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ Another method added by calling `element` is the
 `wait_until_<element_name>_visible` method. Calling this method will
 cause the test to wait for Capybara's default wait time for the element
 to become visible (*not* the same as existence!). You can customise the
-wait time be supplying a number of seconds to wait. Using the above
+wait time by supplying a number of seconds to wait. Using the above
 example:
 
 ```ruby
@@ -651,7 +651,7 @@ it wil return `false`. For example, with the following page:
 
 ```ruby
 class Friends < SitePrism::Page
-  elements(:names, 'ul#names li a')
+  elements :names, 'ul#names li a'
 end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,4 @@ task :rubocop do
   system('bundle exec rubocop') || raise('Cops failed')
 end
 
-task default: %i[rubocop specs cukes]
+task default: %i[specs cukes rubocop]

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -87,7 +87,12 @@ Feature: Waiting for Elements
     And I remove the parent section of the element
     Then I receive an error when a section with the element I am waiting for is removed
 
-  Scenario: Elements Are Not Waited For
+  Scenario: Element Is Not Automatically Waited For
     When I navigate to the home page
     Then the slow element is not waited for
+    And implicit waits are not enabled
+
+  Scenario: Elements Collections Are Not Automatically Waited For
+    When I navigate to the home page
+    Then the slow elements are not waited for
     And implicit waits are not enabled

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -1,6 +1,6 @@
 Feature: Waiting for Elements
 
-  I want to be able to implicitly wait for an element
+  I want to be able to explicitly wait for an element
   In order to interact with the element once it is ready
 
   Scenario: Wait for Element - Positive
@@ -80,9 +80,14 @@ Feature: Waiting for Elements
 
   Scenario: Wait for Invisibility of element - Non-Existent Element
     When I navigate to the home page
-    Then I do not wait for an nonexistent element when checking for invisibility
+    Then I do not wait for a nonexistent element when checking for invisibility
 
   Scenario: Wait for Invisibility of element - Non-Existent Section
     When I navigate to the home page
     And I remove the parent section of the element
     Then I receive an error when a section with the element I am waiting for is removed
+
+  Scenario: Elements Are Not Waited For
+    When I navigate to the home page
+    Then the slow element is not waited for
+    And implicit waits are not enabled

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -96,3 +96,13 @@ Feature: Waiting for Elements
     When I navigate to the home page
     Then the slow elements are not waited for
     And implicit waits are not enabled
+
+  Scenario: Section Is Not Automatically Waited For
+    When I navigate to the home page
+    Then the slow section is not waited for
+    And implicit waits are not enabled
+
+  Scenario: Sections Collections Are Not Automatically Waited For
+    When I navigate to the home page
+    Then the slow sections are not waited for
+    And implicit waits are not enabled

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -90,19 +90,19 @@ Feature: Waiting for Elements
   Scenario: Element Is Not Automatically Waited For
     When I navigate to the home page
     Then the slow element is not waited for
-    And implicit waits are not enabled
+    And implicit waits should not be enabled
 
   Scenario: Elements Collections Are Not Automatically Waited For
     When I navigate to the home page
     Then the slow elements are not waited for
-    And implicit waits are not enabled
+    And implicit waits should not be enabled
 
   Scenario: Section Is Not Automatically Waited For
     When I navigate to the home page
     Then the slow section is not waited for
-    And implicit waits are not enabled
+    And implicit waits should not be enabled
 
   Scenario: Sections Collections Are Not Automatically Waited For
     When I navigate to the home page
     Then the slow sections are not waited for
-    And implicit waits are not enabled
+    And implicit waits should not be enabled

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -7,24 +7,24 @@ Feature: Waiting for Elements Implicitly
   Scenario: Elements Are Automatically Waited For
     When I navigate to the home page
     Then the slow element is waited for
-    And implicit waits are enabled
+    And implicit waits should be enabled
 
   Scenario: Elements Collections Are Automatically Waited For
     When I navigate to the home page
     Then the slow elements are waited for
-    And implicit waits are enabled
+    And implicit waits should be enabled
 
   Scenario: Sections Are Automatically Waited For
     When I navigate to the home page
     Then the slow section is waited for
-    And implicit waits are enabled
+    And implicit waits should be enabled
 
   Scenario: Sections Collections Are Automatically Waited For
     When I navigate to the home page
     Then the slow sections are waited for
-    And implicit waits are enabled
+    And implicit waits should be enabled
 
   Scenario: Wait time can be overridden at run-time
     When I navigate to the home page
     Then the slow element is waited for only as long as a user set Capybara.using_wait_time
-    And implicit waits are enabled
+    And implicit waits should be enabled

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -1,10 +1,15 @@
 @implicit_waits
-Feature: Waiting for Elements
+Feature: Waiting for Elements Implicitly
 
   I want to be able to implicitly wait for an element
   In order to interact with the element once it is ready
 
-  Scenario: Elements Are Waited For
+  Scenario: Elements Are Automatically Waited For
     When I navigate to the home page
     Then the slow element is waited for
+    And implicit waits are enabled
+
+  Scenario: Elements Collections Are Automatically Waited For
+    When I navigate to the home page
+    Then the slow elements are waited for
     And implicit waits are enabled

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -13,3 +13,18 @@ Feature: Waiting for Elements Implicitly
     When I navigate to the home page
     Then the slow elements are waited for
     And implicit waits are enabled
+
+  Scenario: Sections Are Automatically Waited For
+    When I navigate to the home page
+    Then the slow section is waited for
+    And implicit waits are enabled
+
+  Scenario: Sections Collections Are Automatically Waited For
+    When I navigate to the home page
+    Then the slow sections are waited for
+    And implicit waits are enabled
+
+  Scenario: Wait time can be overridden at run-time
+    When I navigate to the home page
+    Then the slow element is waited for only as long as a user set Capybara.using_wait_time
+    And implicit waits are enabled

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -1,0 +1,10 @@
+@implicit_waits
+Feature: Waiting for Elements
+
+  I want to be able to implicitly wait for an element
+  In order to interact with the element once it is ready
+
+  Scenario: Elements Are Waited For
+    When I navigate to the home page
+    Then the slow element is waited for
+    And implicit waits are enabled

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -80,7 +80,7 @@ Then('the previously visible element is invisible') do
   expect(@test_site.home.retiring_element).not_to be_visible
 end
 
-Then('I do not wait for an nonexistent element when checking for invisibility') do
+Then('I do not wait for a nonexistent element when checking for invisibility') do
   start = Time.new
   @test_site.home.wait_until_nonexistent_element_invisible(10)
 

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -85,7 +85,7 @@ Then('the slow section appears') do
     .to have_slow_section_element
 end
 
-Then(/^the removing section disappears$/) do
+Then('the removing section disappears') do
   expect(@test_site.section_experiments.removing_parent_section)
     .not_to have_removing_section_element
 end
@@ -107,11 +107,11 @@ Then("an exception is raised when I wait for a section that won't disappear") do
     .with_message(error_message)
 end
 
-When(/^I wait for the collection of sections that takes a while to disappear$/) do
+When('I wait for the collection of sections that takes a while to disappear') do
   @test_site.home.wait_for_no_removing_sections
 end
 
-Then(/^the removing collection of sections disappears$/) do
+Then('the removing collection of sections disappears') do
   expect(@test_site.home).not_to have_removing_sections
 end
 
@@ -169,71 +169,80 @@ Then('I am not made to wait for the full overridden duration') do
   expect(@duration).to be < @overridden_wait_time
 end
 
-Then(/^implicit waits are enabled$/) do
-  expect(SitePrism.use_implicit_waits).to eq true
+Then('implicit waits should be enabled') do
+  expect(SitePrism.use_implicit_waits).to be true
 end
 
-Then(/^implicit waits are not enabled$/) do
-  expect(SitePrism.use_implicit_waits).to eq false
+Then('implicit waits should not be enabled') do
+  expect(SitePrism.use_implicit_waits).to be false
 end
 
-Then(/^the slow element is not waited for$/) do
+Then('the slow element is not waited for') do
   start_time = Time.now
 
   expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
 
-  expect(Time.now - start_time).to be < 0.5
+  expect(Time.now - start_time).to be < 0.2
 end
 
-Then(/^the slow element is waited for$/) do
+Then('the slow element is waited for') do
   start_time = Time.now
   @test_site.home.some_slow_element
 
-  expect(Time.now - start_time).to be > 1.5
+  expect(Time.now - start_time).to be > 2
 end
 
-Then(/^the slow elements are waited for$/) do
+Then('the slow elements are waited for') do
   start_time = Time.now
   @test_site.home.slow_elements(count: 1)
-  expect(Time.now - start_time).to be > 1.5
+
+  expect(Time.now - start_time).to be > 2
 end
 
-Then(/^the slow elements are not waited for$/) do
+Then('the slow elements are not waited for') do
   start_time = Time.now
+
   expect { @test_site.home.slow_elements(count: 1) }.to raise_error(Capybara::ElementNotFound)
-  expect(Time.now - start_time).to be < 0.5
+
+  expect(Time.now - start_time).to be < 0.2
 end
 
-
-Then(/^the slow section is waited for$/) do
+Then('the slow section is waited for') do
   start_time = Time.now
   @test_site.home.slow_section(count: 1)
-  expect(Time.now - start_time).to be > 1.5
+
+  expect(Time.now - start_time).to be > 2
 end
 
-Then(/^the slow section is not waited for$/) do
+Then('the slow section is not waited for') do
   start_time = Time.now
+
   expect { @test_site.home.slow_section(count: 1) }.to raise_error(Capybara::ElementNotFound)
-  expect(Time.now - start_time).to be < 0.5
+
+  expect(Time.now - start_time).to be < 0.2
 end
 
-Then(/^the slow sections are waited for$/) do
+Then('the slow sections are waited for') do
   start_time = Time.now
   @test_site.home.slow_sections(count: 2)
-  expect(Time.now - start_time).to be > 1.5
+
+  expect(Time.now - start_time).to be > 2
 end
 
-Then(/^the slow sections are not waited for$/) do
+Then('the slow sections are not waited for') do
   start_time = Time.now
+
   expect { @test_site.home.slow_sections(count: 2) }.to raise_error(Capybara::ElementNotFound)
-  expect(Time.now - start_time).to be < 0.5
+
+  expect(Time.now - start_time).to be < 0.2
 end
 
-Then(/^the slow element is waited for only as long as a user set Capybara.using_wait_time$/) do
+Then('the slow element is waited for only as long as a user set Capybara.using_wait_time') do
   start_time = Time.now
   Capybara.using_wait_time(1) do
     expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
   end
-  expect(Time.now - start_time).to be < 2
-  expect(Time.now - start_time).to be > 0.5
+  @duration = Time.now - start_time
+
+  expect(@duration).to be_between(1, 1.1)
 end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -189,14 +189,14 @@ Then('the slow element is waited for') do
   start_time = Time.now
   @test_site.home.some_slow_element
 
-  expect(Time.now - start_time).to be > 2
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
 Then('the slow elements are waited for') do
   start_time = Time.now
   @test_site.home.slow_elements(count: 1)
 
-  expect(Time.now - start_time).to be > 2
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
 Then('the slow elements are not waited for') do
@@ -211,7 +211,7 @@ Then('the slow section is waited for') do
   start_time = Time.now
   @test_site.home.slow_section(count: 1)
 
-  expect(Time.now - start_time).to be > 2
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
 Then('the slow section is not waited for') do
@@ -226,7 +226,7 @@ Then('the slow sections are waited for') do
   start_time = Time.now
   @test_site.home.slow_sections(count: 2)
 
-  expect(Time.now - start_time).to be > 2
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
 Then('the slow sections are not waited for') do

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -203,3 +203,37 @@ Then(/^the slow elements are not waited for$/) do
   expect { @test_site.home.slow_elements(count: 1) }.to raise_error(Capybara::ElementNotFound)
   expect(Time.now - start_time).to be < 0.5
 end
+
+
+Then(/^the slow section is waited for$/) do
+  start_time = Time.now
+  @test_site.home.slow_section(count: 1)
+  expect(Time.now - start_time).to be > 1.5
+end
+
+Then(/^the slow section is not waited for$/) do
+  start_time = Time.now
+  expect { @test_site.home.slow_section(count: 1) }.to raise_error(Capybara::ElementNotFound)
+  expect(Time.now - start_time).to be < 0.5
+end
+
+Then(/^the slow sections are waited for$/) do
+  start_time = Time.now
+  @test_site.home.slow_sections(count: 2)
+  expect(Time.now - start_time).to be > 1.5
+end
+
+Then(/^the slow sections are not waited for$/) do
+  start_time = Time.now
+  expect { @test_site.home.slow_sections(count: 2) }.to raise_error(Capybara::ElementNotFound)
+  expect(Time.now - start_time).to be < 0.5
+end
+
+Then(/^the slow element is waited for only as long as a user set Capybara.using_wait_time$/) do
+  start_time = Time.now
+  Capybara.using_wait_time(1) do
+    expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
+  end
+  expect(Time.now - start_time).to be < 2
+  expect(Time.now - start_time).to be > 0.5
+end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -168,3 +168,23 @@ end
 Then('I am not made to wait for the full overridden duration') do
   expect(@duration).to be < @overridden_wait_time
 end
+
+Then(/^implicit waits are enabled$/) do
+  expect(SitePrism.use_implicit_waits).to eq true
+end
+
+Then(/^implicit waits are not enabled$/) do
+  expect(SitePrism.use_implicit_waits).to eq false
+end
+
+Then(/^the slow element is not waited for$/) do
+  start_time = Time.now
+  @test_site.home.some_slow_element
+  expect(Time.now - start_time).to be < 0.5
+end
+
+Then(/^the slow element is waited for$/) do
+  start_time = Time.now
+  @test_site.home.some_slow_element
+  expect(Time.now - start_time).to be > 1.5
+end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -179,12 +179,27 @@ end
 
 Then(/^the slow element is not waited for$/) do
   start_time = Time.now
-  @test_site.home.some_slow_element
+
+  expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
+
   expect(Time.now - start_time).to be < 0.5
 end
 
 Then(/^the slow element is waited for$/) do
   start_time = Time.now
   @test_site.home.some_slow_element
+
   expect(Time.now - start_time).to be > 1.5
+end
+
+Then(/^the slow elements are waited for$/) do
+  start_time = Time.now
+  @test_site.home.slow_elements(count: 1)
+  expect(Time.now - start_time).to be > 1.5
+end
+
+Then(/^the slow elements are not waited for$/) do
+  start_time = Time.now
+  expect { @test_site.home.slow_elements(count: 1) }.to raise_error(Capybara::ElementNotFound)
+  expect(Time.now - start_time).to be < 0.5
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+Before('~@implicit_waits') do
+  SitePrism.configure do |config|
+    config.use_implicit_waits = false
+  end
+end
+
+Before('@implicit_waits') do
+  SitePrism.configure do |config|
+    config.use_implicit_waits = true
+  end
+end
+
 Before do
   SitePrism.raise_on_wait_fors = false
   @test_site = TestSite.new

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -26,6 +26,16 @@
       var t3 = setTimeout("document.getElementById('will_become_invisible').style.display='none';", 2000);
       var t4 = setTimeout("document.getElementById('will_become_nonexistent').remove();", 2000);
       var t5 = setTimeout("document.getElementById('link_container_will_become_nonexistent').remove();", 2000);
+
+      var slow_section = document.createElement("div");
+      slow_section.className = 'slow-section first';
+      var slow_section2 = document.createElement("div");
+      slow_section2.className = 'slow-section second';
+      setTimeout(function() {
+        [slow_section, slow_section2].forEach(function(item) {
+          dumping_ground.appendChild(item);
+        });
+      }, 2000)
     }
     window.onload = load;
     </script>

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -9,7 +9,7 @@ class TestHomePage < SitePrism::Page
   element :welcome_message, 'body > span'
   element :go_button, '[value="Go!"]'
   element :link_to_search_page, :xpath, '//p[2]/a'
-  # This takes just over 2 seconds to appear
+  # Below element takes just over 2 seconds to appear
   element :some_slow_element, :xpath, '//a[@class="slow"]'
   element :invisible_element, 'input.invisible'
   element :shy_element, 'input#will_become_visible'
@@ -25,7 +25,8 @@ class TestHomePage < SitePrism::Page
   elements :welcome_headers, :xpath, '//h3'
   elements :welcome_messages, :xpath, '//span'
   elements :rows, 'td'
-  elements :slow_elements, :xpath, '//a[@class="slow"]' # note - actually only one
+  # note - actually only one of the below
+  elements :slow_elements, :xpath, '//a[@class="slow"]'
 
   # elements that should not exist
   element :squirrel, 'squirrel.nutz'
@@ -43,12 +44,16 @@ class TestHomePage < SitePrism::Page
   section :removing_section,
           NoElementWithinSection,
           'input#will_become_nonexistent'
+  # `slow_section` takes ~2s to appear
+  section :slow_section, NoElementWithinSection, 'div.first.slow-section'
 
   # section groups
   sections :nonexistent_sections, NoElementWithinSection, 'input#nonexistent'
   sections :removing_sections,
            NoElementWithinSection,
            '#link_container_will_become_nonexistent > a'
+  # `slow_sections` takes ~2s to appear
+  sections :slow_sections, NoElementWithinSection, 'div.slow-section'
 
   # iframes
   iframe :my_iframe, MyIframe, '#the_iframe'

--- a/test_site/pages/home.rb
+++ b/test_site/pages/home.rb
@@ -25,6 +25,7 @@ class TestHomePage < SitePrism::Page
   elements :welcome_headers, :xpath, '//h3'
   elements :welcome_messages, :xpath, '//span'
   elements :rows, 'td'
+  elements :slow_elements, :xpath, '//a[@class="slow"]' # note - actually only one
 
   # elements that should not exist
   element :squirrel, 'squirrel.nutz'


### PR DESCRIPTION
This PR is aimed at doing 3 things.
- Adding a bunch of well written tests from @tgaff - Which have been shamelessly stolen, and very slightly adapted
- Tweaking a little bit of documentation, as well as the run order of the Travis jobs (Again thanks to @tgaff)
- Implicitly (Badoom-tish), show that actually in the Capybara3 rework branch I worked on. I've fixed the implicit waiting issue. The tests shown here were designed against Travis' code, but actually work fine against both master and the code which this is based off.

Note that due to Point 3 - This item requires #277 to be merged in first (Which will then remove the first 11 commits), at which point a review can be undertaken on the new 5 commits here.

TL;DR - After the code contained in this full PR. The next gem can be released which fixes a couple of bugs, clears some tech debt, and enables Capybara 3 support.