### PR TITLE
Fix issue where iFrame is called without a block

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,9 +3,7 @@
 -  `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
 -  Update of Ruby Version to supported version
 -  Rubocop LineLength reduction (Continue this, will be hard work, probably several PR's)
--  Rubocop MethodLength reduction (Should be a small-er PR)
 -  Create iFrame specs (Even though private methods)
--  Allow scoping iFrames to then be passed into element native object
 - Generic spec walkthrough - (have done section/sections/element/elements/top half of page)
 - Advanced spec clean. Make sure each spec file represents the right items
 - Setup a secondary gemfile to track against older items (As and when we upgrade Ruby/Gem deps)

--- a/features/iframes.feature
+++ b/features/iframes.feature
@@ -24,3 +24,6 @@ Feature: IFrame interaction
   Scenario: interact with elements in an iframe
     Then I can see elements in an iframe
     And I can see elements in an iframe with capybara query options
+
+  Scenario: interact with an iframe - Negative
+    Then I cannot interact with an iFrame outside of a block

--- a/features/step_definitions/iframe_steps.rb
+++ b/features/step_definitions/iframe_steps.rb
@@ -53,3 +53,11 @@ Then('I can see elements in an iframe with capybara query options') do
     expect(f).to have_some_text(text: 'Some text in an iframe')
   end
 end
+
+Then('I cannot interact with an iFrame outside of a block') do
+  error_message = 'You can only use iFrames in a block context. See docs for more details.'
+
+  expect { @test_site.home.my_iframe }
+    .to raise_error(SitePrism::BlockMissingError)
+    .with_message(error_message)
+end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -115,6 +115,8 @@ module SitePrism
         add_to_mapped_items(iframe_name)
         add_iframe_helper_methods(iframe_name, *element_find_args)
         define_method(iframe_name) do |&block|
+          raise BlockMissingError unless block_given?
+
           within_frame(*scope_find_args) do
             block.call iframe_page_class.new
           end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -109,16 +109,16 @@ module SitePrism
         end
       end
 
-      def iframe(iframe_name, iframe_page_class, *args)
+      def iframe(name, klass, *args)
         element_find_args = deduce_iframe_element_find_args(args)
         scope_find_args = deduce_iframe_scope_find_args(args)
-        add_to_mapped_items(iframe_name)
-        add_iframe_helper_methods(iframe_name, *element_find_args)
-        define_method(iframe_name) do |&block|
-          raise BlockMissingError unless block_given?
+        add_to_mapped_items(name)
+        add_iframe_helper_methods(name, *element_find_args)
+        define_method(name) do |&block|
+          raise BlockMissingError unless block
 
           within_frame(*scope_find_args) do
-            block.call iframe_page_class.new
+            block.call(klass.new)
           end
         end
       end

--- a/lib/site_prism/exceptions.rb
+++ b/lib/site_prism/exceptions.rb
@@ -30,5 +30,11 @@ Templated port numbers are unsupported."
     end
   end
 
+  class BlockMissingError < StandardError
+    def message
+      'You can only use iFrames in a block context. See docs for more details.'
+    end
+  end
+
   NotLoadedError = Class.new(StandardError)
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 describe SitePrism::Page do
-  shared_examples 'SitePrism Page' do
-    it 'responds to #element' do
+  shared_examples 'element' do
+    it 'should respond to .element' do
       expect(SitePrism::Page).to respond_to(:element)
     end
 
@@ -38,6 +38,7 @@ describe SitePrism::Page do
         allow(page).to receive(:present?).with(:bob).and_return(true)
         allow(page).to receive(:present?).with(:dave).and_return(false)
         allow(page).to receive(:present?).with(:success_msg).and_return(true)
+        allow(page).to receive(:present?).with(:iframe)
       end
 
       it 'only lists the SitePrism objects that are present on the page' do
@@ -65,7 +66,7 @@ describe SitePrism::Page do
     let(:page) { PageCSS.new }
     let(:klass) { PageCSS }
 
-    it_behaves_like 'SitePrism Page'
+    it_behaves_like 'element'
   end
 
   context 'with xpath elements' do
@@ -81,6 +82,6 @@ describe SitePrism::Page do
     let(:page) { PageXPath.new }
     let(:klass) { PageXPath }
 
-    it_behaves_like 'SitePrism Page'
+    it_behaves_like 'element'
   end
 end

--- a/spec/iframe_spec.rb
+++ b/spec/iframe_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'iFrame' do
+  shared_examples 'iFrame' do
+    let(:error_message) do
+      'You can only use iFrames in a block context. See docs for more details.'
+    end
+
+    it 'cannot be called out of block context' do
+      expect { subject.iframe }
+        .to raise_error(SitePrism::BlockMissingError)
+        .with_message(error_message)
+    end
+  end
+
+  context 'with css elements' do
+    class IFrame < SitePrism::Page; end
+
+    class PageCSS < SitePrism::Page
+      iframe :iframe, IFrame, 'a.b c.d'
+    end
+
+    subject { page }
+    let(:page) { PageCSS.new }
+    let(:klass) { PageCSS }
+
+    it_behaves_like 'iFrame'
+  end
+
+  context 'with xpath elements' do
+    class IFrame < SitePrism::Page; end
+
+    class PageXPath < SitePrism::Page
+      iframe :iframe, IFrame, '//w[@class="x"]//y[@class="z"]'
+    end
+
+    subject { page }
+    let(:page) { PageXPath.new }
+    let(:klass) { PageXPath }
+
+    it_behaves_like 'iFrame'
+  end
+end


### PR DESCRIPTION
Fixes issue #227 raised by @mdesantis.

When an iFrame is defined as a Page Object it must be called with a block. Corresponding code and tests added to check for this.