### PR TITLE
Remove procedural block in page.rb

### DIFF
--- a/lib/site_prism/loadable.rb
+++ b/lib/site_prism/loadable.rb
@@ -36,7 +36,26 @@ module SitePrism
       private
 
       def _load_validations
-        @_load_validations ||= []
+        @_load_validations ||= default_validations
+      end
+
+      def default_validations
+        if siteprism_page?
+          [
+            Proc.new do
+              [
+                displayed?,
+                "Expected #{current_url} to match #{url_matcher} but it did not."
+              ]
+            end
+          ]
+        else
+          []
+        end
+      end
+
+      def siteprism_page?
+        self == SitePrism::Page
       end
     end
 

--- a/lib/site_prism/loadable.rb
+++ b/lib/site_prism/loadable.rb
@@ -41,14 +41,7 @@ module SitePrism
 
       def default_validations
         if siteprism_page?
-          [
-            Proc.new do
-              [
-                displayed?,
-                "Expected #{current_url} to match #{url_matcher} but it did not."
-              ]
-            end
-          ]
+          [displayed_validation]
         else
           []
         end
@@ -56,6 +49,15 @@ module SitePrism
 
       def siteprism_page?
         self == SitePrism::Page
+      end
+
+      def displayed_validation
+        proc do
+          [
+            displayed?,
+            "Expected #{current_url} to match #{url_matcher} but it did not."
+          ]
+        end
       end
     end
 

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -10,11 +10,11 @@ module SitePrism
     include Loadable
     include ElementContainer
 
-    load_validation do
-      [
-        displayed?,
-        "Expected #{current_url} to match #{url_matcher} but it did not."
-      ]
+    # When instantiating the page. A single default validation will be added
+    # When calling #load, all of the validations set will be ran
+    # in order, with the default "displayed?" validation being ran first
+    def initialize
+      add_displayed_validation
     end
 
     def page
@@ -139,6 +139,15 @@ module SitePrism
 
     def matcher_template
       @matcher_template ||= AddressableUrlMatcher.new(url_matcher)
+    end
+
+    def add_displayed_validation
+      self.class.load_validation do
+        [
+          displayed?,
+          "Expected #{current_url} to match #{url_matcher} but it did not."
+        ]
+      end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -13,10 +13,7 @@ module SitePrism
     # When instantiating the page. A default validation will be added to all
     # validations you define and add to the Page Class.
     # When calling #load, all of the validations that are set will be ran
-    # in order, with the default "displayed?" validation being ran _LAST_
-    def initialize
-      add_displayed_validation
-    end
+    # in order, with the default "displayed?" validation being ran _FIRST_
 
     def page
       @page || Capybara.current_session
@@ -140,15 +137,6 @@ module SitePrism
 
     def matcher_template
       @matcher_template ||= AddressableUrlMatcher.new(url_matcher)
-    end
-
-    def add_displayed_validation
-      self.class.load_validation do
-        [
-          displayed?,
-          "Expected #{current_url} to match #{url_matcher} but it did not."
-        ]
-      end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -10,9 +10,10 @@ module SitePrism
     include Loadable
     include ElementContainer
 
-    # When instantiating the page. A single default validation will be added
-    # When calling #load, all of the validations set will be ran
-    # in order, with the default "displayed?" validation being ran first
+    # When instantiating the page. A default validation will be added to all
+    # validations you define and add to the Page Class.
+    # When calling #load, all of the validations that are set will be ran
+    # in order, with the default "displayed?" validation being ran _LAST_
     def initialize
       add_displayed_validation
     end

--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -3,7 +3,6 @@
 require 'site_prism/loadable'
 
 module SitePrism
-  # rubocop:disable Metrics/ClassLength
   class Page
     include Capybara::DSL
     include ElementChecker
@@ -139,5 +138,4 @@ module SitePrism
       @matcher_template ||= AddressableUrlMatcher.new(url_matcher)
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end


### PR DESCRIPTION
Clears up one of the 3.0 roadmap comments.

Note that this WILL change the load order and put this item last, however as it's being deprecated / removed I don't foresee an issue with it.