### PR TITLE
Wait key refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,9 @@ BlockLength:
     - './spec/*_spec.rb'
     - 'site_prism.gemspec'
 
-## Offense count: 13
+# Offense count: 7
 Metrics/LineLength:
-  Max: 99
+  Max: 90
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,9 +21,9 @@ BlockLength:
     - './spec/*_spec.rb'
     - 'site_prism.gemspec'
 
-# Offense count: 7
+# Offense count: 4
 Metrics/LineLength:
-  Max: 90
+  Max: 89
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 ### Backlog:
--  `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
--  Create iFrame specs (Even though private methods)
-- Standardise wait key assignment in element container (Work broken out from Capybara3 rework)
+- `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
+- Create iFrame specs (Even though private methods)
 - Create Test Helper and isolate all classes into single definition/s (CSS/XPath pages)
 - Split up `page_spec.rb` into composite test files
 - Split up `section_spec.rb` into composite test files

--- a/features/elements.feature
+++ b/features/elements.feature
@@ -16,10 +16,10 @@ Feature: Interaction with groups of elements
   Scenario: Page with no elements
     Then the page does not have a group of elements
 
-  Scenario: Waiting on a set of elements
+  Scenario: Waiting on a set of elements to appear
     When I wait a variable time for elements to appear
     Then I can wait a variable time and pass specific parameters
 
   Scenario: Waiting on a set of elements to disappear
     When I wait a variable time for elements to disappear
-    Then I can wait a variable time for elements to disappear and pass specific parameters
+    Then waiting a short time for elements to disappear doesn't raise an error

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -71,7 +71,7 @@ Feature: Waiting for Elements
 
   Scenario: Wait for Invisibility of element - Overridden Timeout
     When I navigate to the home page
-    And I wait for a specific amount of time until a particular element is invisible
+    And I wait a specific amount of time for a particular element to vanish
     Then the previously visible element is invisible
 
   Scenario: Wait for Invisibility of element - Negative Test
@@ -80,12 +80,12 @@ Feature: Waiting for Elements
 
   Scenario: Wait for Invisibility of element - Non-Existent Element
     When I navigate to the home page
-    Then I do not wait for a nonexistent element when checking for invisibility
+    Then I am not made to wait to check a nonexistent element for invisibility
 
   Scenario: Wait for Invisibility of element - Non-Existent Section
     When I navigate to the home page
     And I remove the parent section of the element
-    Then I receive an error when a section with the element I am waiting for is removed
+    Then an error is thrown when waiting for an element in a section that disappears
 
   Scenario: Element Is Not Automatically Waited For
     When I navigate to the home page

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -76,7 +76,7 @@ Feature: Waiting for Elements
 
   Scenario: Wait for Invisibility of element - Negative Test
     When I navigate to the home page
-    Then I get a timeout error when I wait for an element that never disappears
+    Then I get a timeout error when I wait for an element that never vanishes
 
   Scenario: Wait for Invisibility of element - Non-Existent Element
     When I navigate to the home page

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -24,7 +24,23 @@ Feature: Waiting for Elements Implicitly
     Then the slow sections are waited for
     And implicit waits should be enabled
 
+  Scenario: Boolean test for Element is Automatically Waited For
+    When I navigate to the home page
+    Then the boolean test for a slow element is waited for
+
+  Scenario: Boolean test for Elements is Automatically Waited For
+    When I navigate to the home page
+    Then the boolean test for slow elements are waited for
+
+  Scenario: Boolean test for Section is Automatically Waited For
+    When I navigate to the home page
+    Then the boolean test for a slow section is waited for
+
+  Scenario: Boolean test for Sections is Automatically Waited For
+    When I navigate to the home page
+    Then the boolean test for slow sections are waited for
+
   Scenario: Wait time can be overridden at run-time
     When I navigate to the home page
-    Then the slow element is waited for only as long as a user set Capybara.using_wait_time
+    Then a slow element is waited for if a user sets Capybara.using_wait_time
     And implicit waits should be enabled

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -80,7 +80,7 @@ Then('the previously visible element is invisible') do
   expect(@test_site.home.retiring_element).not_to be_visible
 end
 
-Then('I do not wait for a nonexistent element when checking for invisibility') do
+Then('I am not made to wait to check a nonexistent element for invisibility') do
   start = Time.new
   @test_site.home.wait_until_nonexistent_element_invisible(10)
 
@@ -91,7 +91,7 @@ When('I remove the parent section of the element') do
   @test_site.home.remove_container_with_element_btn.click
 end
 
-Then('I receive an error when a section with the element I am waiting for is removed') do
+Then('an error is thrown when waiting for an element in a section that disappears') do
   expect do
     @test_site.home.container_with_element.wait_until_embedded_element_invisible
   end.to raise_error(Capybara::ElementNotFound)

--- a/features/step_definitions/elements_steps.rb
+++ b/features/step_definitions/elements_steps.rb
@@ -31,8 +31,8 @@ Then('I can wait a variable time and pass specific parameters') do
   end
 end
 
-Then('I can wait a variable time for elements to disappear and pass specific parameters') do
+Then("waiting a short time for elements to disappear doesn't raise an error") do
   expect do
     @test_site.home.wait_for_no_removing_links(0.1, text: 'wibble')
-  end.not_to raise_error(SitePrism::TimeoutException)
+  end.not_to raise_error
 end

--- a/features/step_definitions/iframe_steps.rb
+++ b/features/step_definitions/iframe_steps.rb
@@ -59,7 +59,8 @@ Then('I can see elements in an iframe with capybara query options') do
 end
 
 Then('I cannot interact with an iFrame outside of a block') do
-  error_message = 'You can only use iFrames in a block context - Please pass in a block.'
+  error_message =
+    'You can only use iFrames in a block context - Please pass in a block.'
 
   expect { @test_site.home.id_iframe }
     .to raise_error(SitePrism::BlockMissingError)

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -71,7 +71,7 @@ Then("the element I am waiting for doesn't disappear in time") do
 end
 
 When('I wait for the section element that takes a while to appear') do
-  @test_site.section_experiments.parent_section.wait_for_slow_section_element
+  @test_site.section_experiments.parent_section.wait_for_slow_element
 end
 
 When('I wait for the section element that takes a while to disappear') do
@@ -82,7 +82,7 @@ end
 
 Then('the slow section appears') do
   expect(@test_site.section_experiments.parent_section)
-    .to have_slow_section_element
+    .to have_slow_element
 end
 
 Then('the removing section disappears') do
@@ -93,9 +93,9 @@ end
 Then("an exception is raised when I wait for a section that won't appear") do
   section = @test_site.section_experiments.parent_section
 
-  expect { section.wait_for_slow_section_element(0.25) }
+  expect { section.wait_for_slow_element(0.25) }
     .to raise_error(SitePrism::TimeOutWaitingForExistenceError)
-    .with_message('Timed out after 0.25s waiting for Parent#slow_section_element')
+    .with_message('Timed out after 0.25s waiting for Parent#slow_element')
 end
 
 Then("an exception is raised when I wait for a section that won't disappear") do
@@ -116,11 +116,11 @@ Then('the removing collection of sections disappears') do
 end
 
 When('I wait a variable time for elements to appear') do
-  @test_site.home.wait_for_lots_of_links(2.1)
+  @test_site.home.wait_for_lots_of_links(1.6)
 end
 
 When('I wait a variable time for elements to disappear') do
-  @test_site.home.wait_for_no_removing_links(2.1)
+  @test_site.home.wait_for_no_removing_links(1.6)
 end
 
 Then('I get a timeout error when I wait for an element that never appears') do
@@ -154,7 +154,7 @@ When('I wait a specific amount of time for a particular element to vanish') do
   @test_site.home.wait_until_retiring_element_invisible(5)
 end
 
-Then('I get a timeout error when I wait for an element that never disappears') do
+Then('I get a timeout error when I wait for an element that never vanishes') do
   expect { @test_site.home.wait_until_welcome_header_invisible(1) }
     .to raise_error(SitePrism::TimeOutWaitingForElementInvisibility)
 end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -116,13 +116,11 @@ Then('the removing collection of sections disappears') do
 end
 
 When('I wait a variable time for elements to appear') do
-  @test_site.home.wait_for_lots_of_links
-  @test_site.home.wait_for_lots_of_links(0.1)
+  @test_site.home.wait_for_lots_of_links(2.1)
 end
 
 When('I wait a variable time for elements to disappear') do
-  @test_site.home.wait_for_no_removing_links
-  @test_site.home.wait_for_no_removing_links(0.1)
+  @test_site.home.wait_for_no_removing_links(2.1)
 end
 
 Then('I get a timeout error when I wait for an element that never appears') do
@@ -152,7 +150,7 @@ When('I wait for an element to become invisible') do
   @test_site.home.wait_until_retiring_element_invisible
 end
 
-When('I wait for a specific amount of time until a particular element is invisible') do
+When('I wait a specific amount of time for a particular element to vanish') do
   @test_site.home.wait_until_retiring_element_invisible(5)
 end
 
@@ -180,7 +178,8 @@ end
 Then('the slow element is not waited for') do
   start_time = Time.now
 
-  expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.some_slow_element }
+    .to raise_error(Capybara::ElementNotFound)
 
   expect(Time.now - start_time).to be < 0.2
 end
@@ -199,10 +198,27 @@ Then('the slow elements are waited for') do
   expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
+Then('the boolean test for a slow element is waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_some_slow_element?).to be true
+
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
+end
+
+Then('the boolean test for slow elements are waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_elements?).to be true
+
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
+end
+
 Then('the slow elements are not waited for') do
   start_time = Time.now
 
-  expect { @test_site.home.slow_elements(count: 1) }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.slow_elements(count: 1) }
+    .to raise_error(Capybara::ElementNotFound)
 
   expect(Time.now - start_time).to be < 0.2
 end
@@ -214,12 +230,29 @@ Then('the slow section is waited for') do
   expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
+Then('the boolean test for a slow section is waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_section?(count: 1)).to be true
+
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
+end
+
 Then('the slow section is not waited for') do
   start_time = Time.now
 
-  expect { @test_site.home.slow_section(count: 1) }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.slow_section(count: 1) }
+    .to raise_error(Capybara::ElementNotFound)
 
   expect(Time.now - start_time).to be < 0.2
+end
+
+Then('the boolean test for slow sections are waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_sections?(count: 2)).to be true
+
+  expect(Time.now - start_time).to be_between(1.85, 2.15)
 end
 
 Then('the slow sections are waited for') do
@@ -232,15 +265,17 @@ end
 Then('the slow sections are not waited for') do
   start_time = Time.now
 
-  expect { @test_site.home.slow_sections(count: 2) }.to raise_error(Capybara::ElementNotFound)
+  expect { @test_site.home.slow_sections(count: 2) }
+    .to raise_error(Capybara::ElementNotFound)
 
   expect(Time.now - start_time).to be < 0.2
 end
 
-Then('the slow element is waited for only as long as a user set Capybara.using_wait_time') do
+Then('a slow element is waited for if a user sets Capybara.using_wait_time') do
   start_time = Time.now
   Capybara.using_wait_time(1) do
-    expect { @test_site.home.some_slow_element }.to raise_error(Capybara::ElementNotFound)
+    expect { @test_site.home.some_slow_element }
+      .to raise_error(Capybara::ElementNotFound)
   end
   @duration = Time.now - start_time
 

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -8,8 +8,16 @@ module SitePrism
 
     private
 
-    def max_wait_time
+    def waiter_wait_time
       Capybara.default_max_wait_time
+    end
+
+    def checker_wait_time
+      if SitePrism.use_implicit_waits
+        waiter_wait_time
+      else
+        0
+      end
     end
 
     def raise_if_block(obj, name, has_block, type)
@@ -169,9 +177,9 @@ module SitePrism
         method_name = "has_#{element_name}?"
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
-            wait_time = SitePrism.use_implicit_waits ? max_wait_time : 0
-            visibility_args = { wait: wait_time }
-            element_exists?(*merge_args(find_args, runtime_args, **visibility_args))
+            visibility_args = { wait: checker_wait_time }
+            args = merge_args(find_args, runtime_args, **visibility_args)
+            element_exists?(*args)
           end
         end
       end
@@ -180,11 +188,9 @@ module SitePrism
         method_name = "has_no_#{element_name}?"
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
-            wait_time = SitePrism.use_implicit_waits ? max_wait_time : 0
-            visibility_args = { wait: wait_time }
-            element_does_not_exist?(
-              *merge_args(find_args, runtime_args, **visibility_args)
-            )
+            visibility_args = { wait: checker_wait_time }
+            args = merge_args(find_args, runtime_args, **visibility_args)
+            element_does_not_exist?(*args)
           end
         end
       end
@@ -192,10 +198,11 @@ module SitePrism
       def create_waiter(element_name, *find_args)
         method_name = "wait_for_#{element_name}"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = max_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
             visibility_args = { wait: timeout }
-            result = element_exists?(*merge_args(find_args, runtime_args, **visibility_args))
-            raise_wait_for_if_failed(self, element_name.to_s, timeout, !result)
+            args = merge_args(find_args, runtime_args, **visibility_args)
+            result = element_exists?(*args)
+            raise_wait_for_if_failed(self, element_name, timeout, !result)
             result
           end
         end
@@ -204,11 +211,12 @@ module SitePrism
       def create_nonexistence_waiter(element_name, *find_args)
         method_name = "wait_for_no_#{element_name}"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = max_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
             visibility_args = { wait: timeout }
-            res = element_does_not_exist?(*merge_args(find_args, runtime_args, **visibility_args))
-            raise_wait_for_no_if_failed(self, element_name.to_s, timeout, !res)
-            res
+            args = merge_args(find_args, runtime_args, **visibility_args)
+            result = element_does_not_exist?(*args)
+            raise_wait_for_no_if_failed(self, element_name, timeout, !result)
+            result
           end
         end
       end
@@ -216,7 +224,7 @@ module SitePrism
       def create_visibility_waiter(element_name, *find_args)
         method_name = "wait_until_#{element_name}_visible"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = max_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
             visibility_args = { visible: true, wait: timeout }
             args = merge_args(find_args, runtime_args, **visibility_args)
             return true if element_exists?(*args)
@@ -228,7 +236,7 @@ module SitePrism
       def create_invisibility_waiter(element_name, *find_args)
         method_name = "wait_until_#{element_name}_invisible"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = max_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
             visibility_args = { visible: true, wait: timeout }
             args = merge_args(find_args, runtime_args, **visibility_args)
             return true if element_does_not_exist?(*args)

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -8,13 +8,13 @@ module SitePrism
 
     private
 
-    def waiter_wait_time
+    def wait_time
       Capybara.default_max_wait_time
     end
 
     def checker_wait_time
       if SitePrism.use_implicit_waits
-        waiter_wait_time
+        wait_time
       else
         0
       end
@@ -178,7 +178,7 @@ module SitePrism
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
             visibility_args = { wait: checker_wait_time }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             element_exists?(*args)
           end
         end
@@ -189,7 +189,7 @@ module SitePrism
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
             visibility_args = { wait: checker_wait_time }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             element_does_not_exist?(*args)
           end
         end
@@ -198,9 +198,9 @@ module SitePrism
       def create_waiter(element_name, *find_args)
         method_name = "wait_for_#{element_name}"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = wait_time, *runtime_args|
             visibility_args = { wait: timeout }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             result = element_exists?(*args)
             raise_wait_for_if_failed(self, element_name, timeout, !result)
             result
@@ -211,9 +211,9 @@ module SitePrism
       def create_nonexistence_waiter(element_name, *find_args)
         method_name = "wait_for_no_#{element_name}"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = wait_time, *runtime_args|
             visibility_args = { wait: timeout }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             result = element_does_not_exist?(*args)
             raise_wait_for_no_if_failed(self, element_name, timeout, !result)
             result
@@ -224,9 +224,9 @@ module SitePrism
       def create_visibility_waiter(element_name, *find_args)
         method_name = "wait_until_#{element_name}_visible"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = wait_time, *runtime_args|
             visibility_args = { visible: true, wait: timeout }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             return true if element_exists?(*args)
             raise SitePrism::TimeOutWaitingForElementVisibility
           end
@@ -236,9 +236,9 @@ module SitePrism
       def create_invisibility_waiter(element_name, *find_args)
         method_name = "wait_until_#{element_name}_invisible"
         create_helper_method(method_name, *find_args) do
-          define_method(method_name) do |timeout = waiter_wait_time, *runtime_args|
+          define_method(method_name) do |timeout = wait_time, *runtime_args|
             visibility_args = { visible: true, wait: timeout }
-            args = merge_args(find_args, runtime_args, **visibility_args)
+            args = merge_args(find_args, runtime_args, visibility_args)
             return true if element_does_not_exist?(*args)
             raise SitePrism::TimeOutWaitingForElementInvisibility
           end

--- a/lib/site_prism/error.rb
+++ b/lib/site_prism/error.rb
@@ -80,10 +80,11 @@ module SitePrism
   InvalidUrlMatcher                    = InvalidUrlMatcherError
   NoSelectorForElement                 = InvalidElementError
   TimeoutException                     = TimeoutError
-  TimeOutWaitingForExistenceError      = Class.new(StandardError) # To avoid message leaking
-  TimeOutWaitingForNonExistenceError   = Class.new(StandardError) # To avoid message leaking
-  TimeOutWaitingForElementVisibility   = Class.new(StandardError) # To avoid message leaking
-  TimeOutWaitingForElementInvisibility = Class.new(StandardError) # To avoid message leaking
+  # Below four have different inheritance for now to avoid message leaking
+  TimeOutWaitingForExistenceError      = Class.new(StandardError)
+  TimeOutWaitingForNonExistenceError   = Class.new(StandardError)
+  TimeOutWaitingForElementVisibility   = Class.new(StandardError)
+  TimeOutWaitingForElementInvisibility = Class.new(StandardError)
   UnsupportedBlock                     = UnsupportedBlockError
   BlockMissingError                    = MissingBlockError
   NotLoadedError                       = FailedLoadValidationError

--- a/test_site/pages/section_experiments.rb
+++ b/test_site/pages/section_experiments.rb
@@ -33,7 +33,8 @@ class TestSectionExperiments < SitePrism::Page
 
   def cell_value=(value)
     execute_script(
-      "document.getElementById('first_search_result').children[0].innerHTML = '#{value}'"
+      "document.getElementById('first_search_result').children[0].innerHTML =
+        '#{value}'"
     )
   end
 

--- a/test_site/sections/parent.rb
+++ b/test_site/sections/parent.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class Parent < SitePrism::Section
-  element :slow_section_element, 'a.slow'
+  element :slow_element, 'a.slow'
   section :child_section, Child, '.child-div'
 end

--- a/test_site/sections/search_result.rb
+++ b/test_site/sections/search_result.rb
@@ -6,7 +6,8 @@ class SearchResult < SitePrism::Section
 
   def cell_value=(value)
     execute_script(
-      "document.getElementById('first_search_result').children[0].innerHTML = '#{value}'"
+      "document.getElementById('first_search_result').children[0].innerHTML =
+        '#{value}'"
     )
   end
 


### PR DESCRIPTION
All wait keys are now assigned in the same way (Added new private methods to determine which wait time to use)
Fixed up a load of old language that described poorly named features/scenarios
Rubocop minor tidy (Only 7 linelength failures)