### PR TITLE
API standardisation - Initial Part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/*
 .bundle
 .idea
 .env
+.cucumber-timings

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,4 @@
 ### Backlog:
 - `SitePrism::Page#wait_until_displayed` - Re-call existing method and re-raise
-- Create iFrame specs (Even though private methods)
 - Create Test Helper and isolate all classes into single definition/s (CSS/XPath pages)
-- Split up `page_spec.rb` into composite test files
-- Split up `section_spec.rb` into composite test files
+- v3 rework as per issue template

--- a/features/element.feature
+++ b/features/element.feature
@@ -17,6 +17,7 @@ Feature: Element Methods
     Then the page does not have element
     And the welcome header is not matched with invalid text
 
+  @medium-speed
   Scenario: Element Properties
     When I navigate to the home page
     Then I can see the the HREF of the link
@@ -26,14 +27,16 @@ Feature: Element Methods
     When I navigate to the home page that contains expected elements
     Then all elements marked as expected are present
 
+  @medium-speed
   Scenario: Expected Elements Present - Negative
-    When I navigate to the home page
+    When I navigate to a page with no title
     Then not all expected elements are present
 
   Scenario: Elements Present - Positive
     When I navigate to the letter A page
     Then all mapped elements are present
 
+  @slow-speed
   Scenario: Elements Present - Negative
     When I navigate to the home page
     Then not all mapped elements are present

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -3,14 +3,14 @@ Feature: Waiting for Elements
   I want to be able to explicitly wait for an element
   In order to interact with the element once it is ready
 
-  @implicit_waits @migrated
+  @migrated
   Scenario: Wait for Element - Positive
     When I navigate to the home page
     And I wait for the element that takes a while to appear
     Then the slow element appears
     And I am not made to wait for the full default duration
 
-  @implicit_waits @migrated
+  @migrated
   Scenario: Wait for Element - Exceptions - Negative
     When I navigate to the home page
     Then an exception is raised when I wait for an element that won't appear
@@ -65,23 +65,3 @@ Feature: Waiting for Elements
     When I navigate to the home page
     And I remove the parent section of the element
     Then an error is thrown when waiting for an element in a vanishing section
-
-  Scenario: Element Is Not Automatically Waited For
-    When I navigate to the home page
-    Then the slow element is not waited for
-    And implicit waits should not be enabled
-
-  Scenario: Elements Collections Are Not Automatically Waited For
-    When I navigate to the home page
-    Then the slow elements are not waited for
-    And implicit waits should not be enabled
-
-  Scenario: Section Is Not Automatically Waited For
-    When I navigate to the home page
-    Then the slow section is not waited for
-    And implicit waits should not be enabled
-
-  Scenario: Sections Collections Are Not Automatically Waited For
-    When I navigate to the home page
-    Then the slow sections are not waited for
-    And implicit waits should not be enabled

--- a/features/explicit_waiting.feature
+++ b/features/explicit_waiting.feature
@@ -65,3 +65,7 @@ Feature: Waiting for Elements
     When I navigate to the home page
     And I remove the parent section of the element
     Then an error is thrown when waiting for an element in a vanishing section
+
+  Scenario: Wait time can be overridden at run-time in a block
+    When I navigate to the home page
+    Then I can override the wait time using a Capybara.using_wait_time block

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -34,7 +34,3 @@ Feature: Waiting for Elements Implicitly
   Scenario: Boolean test for Sections is Automatically Waited For
     When I navigate to the home page
     Then the boolean test for slow sections are waited for
-
-  Scenario: Wait time can be overridden at run-time
-    When I navigate to the home page
-    Then I can override the waiting time using Capybara.using_wait_time

--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -1,4 +1,3 @@
-@implicit_waits
 Feature: Waiting for Elements Implicitly
 
   I want to be able to implicitly wait for an element
@@ -7,22 +6,18 @@ Feature: Waiting for Elements Implicitly
   Scenario: Element is Automatically Waited For
     When I navigate to the home page
     Then the slow element is waited for
-    And implicit waits should be enabled
 
   Scenario: Elements are Automatically Waited For
     When I navigate to the home page
     Then the slow elements are waited for
-    And implicit waits should be enabled
 
   Scenario: Section is Automatically Waited For
     When I navigate to the home page
     Then the slow section is waited for
-    And implicit waits should be enabled
 
   Scenario: Sections are Automatically Waited For
     When I navigate to the home page
     Then the slow sections are waited for
-    And implicit waits should be enabled
 
   Scenario: Boolean test for Element is Automatically Waited For
     When I navigate to the home page
@@ -43,4 +38,3 @@ Feature: Waiting for Elements Implicitly
   Scenario: Wait time can be overridden at run-time
     When I navigate to the home page
     Then I can override the waiting time using Capybara.using_wait_time
-    And implicit waits should be enabled

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -82,7 +82,7 @@ end
 
 Then('I am not made to wait to check a nonexistent element for invisibility') do
   start = Time.new
-  @test_site.home.wait_until_nonexistent_element_invisible(10)
+  @test_site.home.wait_until_nonexistent_element_invisible(wait: 10)
 
   expect(Time.new - start).to be < 1
 end

--- a/features/step_definitions/element_steps.rb
+++ b/features/step_definitions/element_steps.rb
@@ -55,7 +55,7 @@ Then('I can see the CLASS of the link') do
 end
 
 Then('not all expected elements are present') do
-  expect(@test_site.home).not_to be_all_there
+  expect(@test_site.no_title).not_to be_all_there
 end
 
 Then('all elements marked as expected are present') do

--- a/features/step_definitions/explicit_waiting_steps.rb
+++ b/features/step_definitions/explicit_waiting_steps.rb
@@ -2,7 +2,7 @@
 
 When('I wait for the element that takes a while to appear') do
   start_time = Time.now
-  @test_site.home.some_slow_element
+  @test_site.home.some_slow_element(wait: 2)
   @duration = Time.now - start_time
 end
 
@@ -32,7 +32,7 @@ Then("an exception is raised when I wait for an element that won't appear") do
 end
 
 Then("an exception is raised when I wait for an element that won't vanish") do
-  expect { @test_site.home.wait_until_removing_element_invisible(1) }
+  expect { @test_site.home.wait_until_removing_element_invisible(wait: 1) }
     .to raise_error(SitePrism::ElementInvisibilityTimeoutError)
 end
 
@@ -63,7 +63,7 @@ end
 Then("an exception is raised when I wait for a section that won't disappear") do
   page = @test_site.section_experiments
 
-  expect { page.wait_until_anonymous_section_invisible(0.15) }
+  expect { page.wait_until_anonymous_section_invisible(wait: 0.15) }
     .to raise_error(SitePrism::ElementInvisibilityTimeoutError)
 end
 
@@ -126,111 +126,7 @@ Then('I am not made to wait for the full overridden duration') do
   expect(@duration).to be < @overridden_wait_time
 end
 
-Then('implicit waits should be enabled') do
-  expect(SitePrism.use_implicit_waits).to be true
-end
-
-Then('implicit waits should not be enabled') do
-  expect(SitePrism.use_implicit_waits).to be false
-end
-
-Then('the slow element is not waited for') do
-  start_time = Time.now
-
-  expect { @test_site.home.some_slow_element }
-    .to raise_error(Capybara::ElementNotFound)
-
-  expect(Time.now - start_time).to be < 0.2
-end
-
-Then('the slow element is waited for') do
-  start_time = Time.now
-  @test_site.home.some_slow_element
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the slow elements are waited for') do
-  start_time = Time.now
-  @test_site.home.slow_elements(count: 1)
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the boolean test for a slow element is waited for') do
-  start_time = Time.now
-
-  expect(@test_site.home.has_some_slow_element?).to be true
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the boolean test for slow elements are waited for') do
-  start_time = Time.now
-
-  expect(@test_site.home.has_slow_elements?).to be true
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the slow elements are not waited for') do
-  start_time = Time.now
-
-  expect { @test_site.home.slow_elements(count: 1) }
-    .to raise_error(Capybara::ElementNotFound)
-
-  expect(Time.now - start_time).to be < 0.2
-end
-
-Then('the slow section is waited for') do
-  start_time = Time.now
-  @test_site.home.slow_section(count: 1)
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the boolean test for a slow section is waited for') do
-  start_time = Time.now
-
-  expect(@test_site.home.has_slow_section?(count: 1)).to be true
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the slow section is not waited for') do
-  start_time = Time.now
-
-  expect { @test_site.home.slow_section(count: 1) }
-    .to raise_error(Capybara::ElementNotFound)
-
-  expect(Time.now - start_time).to be < 0.2
-end
-
-Then('the boolean test for slow sections are waited for') do
-  start_time = Time.now
-
-  expect(@test_site.home.has_slow_sections?(count: 2)).to be true
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the slow sections are waited for') do
-  start_time = Time.now
-  @test_site.home.slow_sections(count: 2)
-
-  expect(Time.now - start_time).to be_between(1.6, 1.9)
-end
-
-Then('the slow sections are not waited for') do
-  start_time = Time.now
-
-  expect { @test_site.home.slow_sections(count: 2) }
-    .to raise_error(Capybara::ElementNotFound)
-
-  expect(Time.now - start_time).to be < 0.2
-end
-
-Then('I can override the waiting time using Capybara.using_wait_time') do
+Then('I can override the wait time using a Capybara.using_wait_time block') do
   start_time = Time.now
   Capybara.using_wait_time(1) do
     expect { @test_site.home.some_slow_element }

--- a/features/step_definitions/implicit_waiting_steps.rb
+++ b/features/step_definitions/implicit_waiting_steps.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+Then('the slow element is waited for') do
+  start_time = Time.now
+  @test_site.home.some_slow_element
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the slow elements are waited for') do
+  start_time = Time.now
+  @test_site.home.slow_elements(count: 1)
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the slow section is waited for') do
+  start_time = Time.now
+  @test_site.home.slow_section(count: 1)
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the slow sections are waited for') do
+  start_time = Time.now
+  @test_site.home.slow_sections(count: 2)
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the boolean test for a slow element is waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_some_slow_element?).to be true
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the boolean test for slow elements are waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_elements?).to be true
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the boolean test for a slow section is waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_section?(count: 1)).to be true
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end
+
+Then('the boolean test for slow sections are waited for') do
+  start_time = Time.now
+
+  expect(@test_site.home.has_slow_sections?(count: 2)).to be true
+
+  expect(Time.now - start_time).to be_between(1, 1.3)
+end

--- a/features/step_definitions/wait_steps.rb
+++ b/features/step_definitions/wait_steps.rb
@@ -85,7 +85,7 @@ end
 Then('I get a timeout error when I wait for an element that never appears') do
   start_time = Time.now
 
-  expect { @test_site.home.wait_until_invisible_element_visible(1) }
+  expect { @test_site.home.wait_until_invisible_element_visible(wait: 1) }
     .to raise_error(SitePrism::ElementVisibilityTimeoutError)
   @duration = Time.now - start_time
 
@@ -101,7 +101,7 @@ end
 When('I wait for a specific amount of time until an element is visible') do
   @overridden_wait_time = 3.5
   start_time = Time.now
-  @test_site.home.wait_until_shy_element_visible(@overridden_wait_time)
+  @test_site.home.wait_until_shy_element_visible(wait: @overridden_wait_time)
   @duration = Time.now - start_time
 end
 
@@ -110,11 +110,11 @@ When('I wait for an element to become invisible') do
 end
 
 When('I wait a specific amount of time for a particular element to vanish') do
-  @test_site.home.wait_until_retiring_element_invisible(5)
+  @test_site.home.wait_until_retiring_element_invisible(wait: 5)
 end
 
 Then('I get a timeout error when I wait for an element that never vanishes') do
-  expect { @test_site.home.wait_until_welcome_header_invisible(1) }
+  expect { @test_site.home.wait_until_welcome_header_invisible(wait: 1) }
     .to raise_error(SitePrism::ElementInvisibilityTimeoutError)
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,13 +34,9 @@ require 'pages/section_experiments'
 
 Capybara.configure do |config|
   config.default_driver = :selenium
-  config.default_max_wait_time = 5
+  config.default_max_wait_time = 2
   config.app_host = 'file://' + File.dirname(__FILE__) + '/../../test_site/html'
   config.ignore_hidden_elements = false
-end
-
-SitePrism.configure do |config|
-  config.use_implicit_waits = false
 end
 
 Capybara.register_driver :selenium do |app|
@@ -50,5 +46,5 @@ end
 private
 
 def browser
-  @browser ||= ENV.fetch('browser', 'firefox').to_sym
+  ENV.fetch('browser', 'firefox').to_sym
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-Before('not @implicit_waits') do
-  SitePrism.configure do |config|
-    config.use_implicit_waits = false
-  end
-end
-
-Before('@implicit_waits') do
-  SitePrism.configure do |config|
-    config.use_implicit_waits = true
-  end
-end
-
 Before do
   @test_site = TestSite.new
+end
+
+Before('@slow-speed') do
+  Capybara.default_max_wait_time = 0.3
+end
+
+Before('@medium-speed') do
+  Capybara.default_max_wait_time = 1.4
+end
+
+After('@slow-speed, @medium-speed') do
+  Capybara.default_max_wait_time = 2
 end

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -12,12 +12,9 @@ module SitePrism
   autoload :AddressableUrlMatcher, 'site_prism/addressable_url_matcher'
 
   class << self
-    attr_accessor :use_implicit_waits
-
     def configure
-      yield self
+      warn 'SitePrism configuration is now removed.'
+      warn 'All options fed directly from Capybara.'
     end
   end
-
-  @use_implicit_waits = true
 end

--- a/lib/site_prism/element_checker.rb
+++ b/lib/site_prism/element_checker.rb
@@ -14,15 +14,15 @@ module SitePrism
 
     def elements_to_check
       if self.class.expected_items
-        mapped_items.select do |el|
-          self.class.expected_items.include?(el)
-        end
+        mapped_items.select { |el| self.class.expected_items.include?(el) }
       else
         mapped_items
       end
     end
 
     def mapped_items
+      return unless self.class.mapped_items
+
       self.class.mapped_items.uniq
     end
 

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -24,12 +24,12 @@ module SitePrism
     #
     # Accepts any combination of arguments sent at DSL definition or runtime
     # and combines them in such a way that Capybara can operate with them.
-    def merge_args(find_args, runtime_args, override_options = {})
+    def merge_args(find_args, runtime_args, visibility_args = {})
       find_args = find_args.dup
       runtime_args = runtime_args.dup
       options = {}
 
-      options.merge!(override_options)
+      options.merge!(visibility_args)
       options.merge!(find_args.pop) if find_args.last.is_a? Hash
       options.merge!(runtime_args.pop) if runtime_args.last.is_a? Hash
 
@@ -167,8 +167,7 @@ module SitePrism
         method_name = "wait_until_#{element_name}_visible"
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
-            hash_args = { visible: true }
-            args = merge_args(find_args, runtime_args, hash_args)
+            args = merge_args(find_args, runtime_args, visible: true)
             return true if element_exists?(*args)
             raise SitePrism::ElementVisibilityTimeoutError
           end
@@ -179,8 +178,7 @@ module SitePrism
         method_name = "wait_until_#{element_name}_invisible"
         create_helper_method(method_name, *find_args) do
           define_method(method_name) do |*runtime_args|
-            hash_args = { visible: true }
-            args = merge_args(find_args, runtime_args, hash_args)
+            args = merge_args(find_args, runtime_args, visible: true)
             return true if element_does_not_exist?(*args)
             raise SitePrism::ElementInvisibilityTimeoutError
           end

--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -21,18 +21,17 @@ module SitePrism
 
     # Sanitize method called before calling any SitePrism DSL method or
     # meta-programmed method. This ensures that the Capybara query is correct.
-    #
     # Accepts any combination of arguments sent at DSL definition or runtime
     # and combines them in such a way that Capybara can operate with them.
+    # Initially it will duplicate all locators and run-time arguments,
+    # then it will combine them with any visibility arguments if defined.
     def merge_args(find_args, runtime_args, visibility_args = {})
       find_args = find_args.dup
       runtime_args = runtime_args.dup
-      options = {}
 
-      options.merge!(visibility_args)
+      options = visibility_args
       options.merge!(find_args.pop) if find_args.last.is_a? Hash
       options.merge!(runtime_args.pop) if runtime_args.last.is_a? Hash
-
       options[:wait] = wait_time unless wait_key_present?(options)
 
       return [*find_args, *runtime_args] if options.empty?

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -2,20 +2,14 @@
 
 require 'spec_helper'
 
-describe SitePrism do
-  after(:all) do
-    SitePrism.configure do |config|
-      config.use_implicit_waits = true
-    end
-  end
+describe 'SitePrism configuration' do
+  subject { SitePrism.configure { |config| config.unused_config = true } }
 
-  it 'should have implicit waits disabled by default' do
-    expect(SitePrism.use_implicit_waits).to be true
-  end
+  let(:warning_message_one) { 'SitePrism configuration is now removed.' }
+  let(:warning_message_two) { 'All options fed directly from Capybara.' }
+  let(:warning_message) { "#{warning_message_one}\n#{warning_message_two}\n" }
 
-  it 'can be configured to not use implicit waits' do
-    SitePrism.configure { |config| config.use_implicit_waits = false }
-
-    expect(SitePrism.use_implicit_waits).to be false
+  it 'should warn users that no more configuration is possible' do
+    expect { subject }.to output(warning_message).to_stderr
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -17,7 +17,6 @@ describe SitePrism::Page do
     it { is_expected.to respond_to(:has_no_bob?) }
     it { is_expected.to respond_to(:wait_until_bob_visible) }
     it { is_expected.to respond_to(:wait_until_bob_invisible) }
-    it { is_expected.to respond_to(:all_there?) }
 
     describe '#all_there?' do
       subject { page.all_there? }
@@ -46,8 +45,6 @@ describe SitePrism::Page do
       end
 
       it 'only lists the SitePrism objects that are present on the page' do
-        p subject
-
         expect(subject.elements_present).to eq(%i[bob success_msg])
       end
     end

--- a/spec/elements_spec.rb
+++ b/spec/elements_spec.rb
@@ -4,15 +4,8 @@ require 'spec_helper'
 
 describe SitePrism::Page do
   shared_examples 'elements' do
-    it { is_expected.to respond_to(:bobs) }
-    it { is_expected.to respond_to(:has_bobs?) }
-    it { is_expected.to respond_to(:has_no_bobs?) }
-    it { is_expected.to respond_to(:wait_until_bobs_visible) }
-    it { is_expected.to respond_to(:wait_until_bobs_invisible) }
-    it { is_expected.to respond_to(:all_there?) }
-
     it 'should return an enumerable result' do
-      expect(subject.bobs).to be_a Capybara::Result
+      expect(page.bobs).to be_a Capybara::Result
     end
 
     describe '.elements' do
@@ -29,7 +22,6 @@ describe SitePrism::Page do
       elements :bobs, 'a.b c.d'
     end
 
-    subject { page }
     let(:page) { PageCSS3.new }
     let(:klass) { PageCSS3 }
 
@@ -41,7 +33,6 @@ describe SitePrism::Page do
       elements :bobs, '//a[@class="b"]//c[@class="d"]'
     end
 
-    subject { page }
     let(:page) { PageXPath3.new }
     let(:klass) { PageXPath3 }
 

--- a/spec/iframe_spec.rb
+++ b/spec/iframe_spec.rb
@@ -65,7 +65,7 @@ describe 'iFrame' do
 
       expect_any_instance_of(IframePage)
         .to receive(:_find)
-        .with('.some_element')
+        .with('.some_element', wait: 0)
         .and_return(locator)
 
       page.frame(&:a)
@@ -91,7 +91,7 @@ describe 'iFrame' do
 
       expect_any_instance_of(IframePage)
         .to receive(:_find)
-        .with('.some_element')
+        .with('.some_element', wait: 0)
         .and_return(locator)
 
       section.frame(&:a)

--- a/spec/iframe_spec.rb
+++ b/spec/iframe_spec.rb
@@ -12,7 +12,7 @@ describe 'iFrame' do
     end
 
     it 'cannot be called out of block context' do
-      expect { subject.iframe }
+      expect { page.iframe }
         .to raise_error(SitePrism::MissingBlockError)
         .with_message(error_message)
     end
@@ -25,7 +25,6 @@ describe 'iFrame' do
       iframe :iframe, IFrame, 'a.b c.d'
     end
 
-    subject { page }
     let(:page) { PageCSS2.new }
     let(:klass) { PageCSS2 }
 
@@ -39,7 +38,6 @@ describe 'iFrame' do
       iframe :iframe, IFrame, '//w[@class="x"]//y[@class="z"]'
     end
 
-    subject { page }
     let(:page) { PageXPath2.new }
     let(:klass) { PageXPath2 }
 

--- a/spec/loadable_spec.rb
+++ b/spec/loadable_spec.rb
@@ -201,8 +201,6 @@ when all load validations pass" do
       expect(instance.load_error).to eq('fubar')
     end
 
-    it 'passes by default as there are 0 load validations' do
-      is_expected.to be_loaded
-    end
+    it { is_expected.to be_loaded }
   end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -385,13 +385,13 @@ from the be_displayed matcher" do
       it 'lets you get at the captures' do
         swap_current_url('http://localhost:3000/foos/15')
 
-        expect(page.url_matches[1]).to eq '15'
+        expect(page.url_matches[1]).to eq('15')
       end
 
       it "returns nil if current_url doesn't match the url_matcher" do
         swap_current_url('http://localhost:3000/bars/15')
 
-        expect(page.url_matches).to eq nil
+        expect(page.url_matches).to be nil
       end
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -82,6 +82,8 @@ is called before the matcher has been set" do
       .with_message('Home#nonexistent_sections does not accept blocks.')
   end
 
+  it { is_expected.to respond_to(*Capybara::Session::DSL_METHODS) }
+
   describe '#page' do
     subject { page_with_url.page }
 

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -144,7 +144,7 @@ class or/and a block as the second argument."
       let(:search_arguments) { ['.other-section'] }
 
       it 'returns the search arguments for a section' do
-        expect(page).to receive(:_find).with(*search_arguments)
+        expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
         page.section_with_locator
       end
@@ -153,7 +153,7 @@ class or/and a block as the second argument."
     context 'search arguments are not provided during the DSL definition' do
       context 'default search arguments are set on both parent and section' do
         it 'returns the default search arguments set on the section' do
-          expect(page).to receive(:_find).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
           page.section_using_defaults
         end
@@ -161,7 +161,7 @@ class or/and a block as the second argument."
 
       context 'default search arguments are only set on the parent section' do
         it 'returns the default search arguments set on the parent section' do
-          expect(page).to receive(:_find).with(*search_arguments)
+          expect(page).to receive(:_find).with(*search_arguments, **dont_wait)
 
           page.section_using_defaults_from_parent
         end
@@ -256,7 +256,7 @@ set_default_search_arguments within section class"
       it 'passes in a hash of query arguments' do
         expect(page)
           .to receive(:_find)
-          .with(*locator_args, **query_args)
+          .with(*locator_args, **query_args, **dont_wait)
 
         page.new_section
       end
@@ -267,7 +267,7 @@ set_default_search_arguments within section class"
       let(:locator_args) { '.class-two' }
 
       it 'passes in an empty hash, which is then sanitized out' do
-        expect(page).to receive(:_find).with(*locator_args)
+        expect(page).to receive(:_find).with(*locator_args, **dont_wait)
 
         page.new_element
       end

--- a/spec/section_spec.rb
+++ b/spec/section_spec.rb
@@ -2,9 +2,20 @@
 
 require 'spec_helper'
 
-describe SitePrism::Page do
+describe SitePrism::Section do
   class Section < SitePrism::Section; end
   class Page < SitePrism::Page; end
+
+  let(:dont_wait) { { wait: 0 } }
+  let(:section_without_block) { SitePrism::Section.new(Page.new, locator) }
+  let!(:locator) { instance_double('Capybara::Node::Element') }
+  let(:section_with_block) do
+    SitePrism::Section.new(Page.new, locator) { 1 + 1 }
+  end
+
+  it 'responds to Capybara methods' do
+    expect(section_without_block).to respond_to(*Capybara::Session::DSL_METHODS)
+  end
 
   describe '.section' do
     it 'should be settable' do
@@ -176,16 +187,6 @@ set_default_search_arguments within section class"
     end
   end
 
-  it { is_expected.to respond_to(*Capybara::Session::DSL_METHODS) }
-end
-
-describe SitePrism::Section do
-  let(:section_without_block) { SitePrism::Section.new(Page.new, locator) }
-  let!(:locator) { instance_double('Capybara::Node::Element') }
-  let(:section_with_block) do
-    SitePrism::Section.new(Page.new, locator) { 1 + 1 }
-  end
-
   describe '.default_search_arguments' do
     class BaseSection < SitePrism::Section
       set_default_search_arguments :css, 'a.b'
@@ -316,10 +317,6 @@ describe SitePrism::Section do
 
       section_without_block.evaluate_script('How High?') == 'To the sky!'
     end
-  end
-
-  it 'responds to Capybara methods' do
-    expect(section_without_block).to respond_to(*Capybara::Session::DSL_METHODS)
   end
 
   describe '#parent_page' do

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -42,7 +42,7 @@ and without search arguments" do
     before do
       allow(subject)
         .to receive(:_all)
-        .with(*search_arguments)
+        .with(*search_arguments, wait: 0)
         .and_return(%i[element1 element2])
     end
 

--- a/spec/sections_spec.rb
+++ b/spec/sections_spec.rb
@@ -24,13 +24,6 @@ describe SitePrism::Page do
     end
   end
 
-  it { is_expected.to respond_to(:plural_sections) }
-  it { is_expected.to respond_to(:has_plural_sections?) }
-  it { is_expected.to respond_to(:has_no_plural_sections?) }
-  it { is_expected.to respond_to(:wait_until_plural_sections_visible) }
-  it { is_expected.to respond_to(:wait_until_plural_sections_invisible) }
-  it { is_expected.to respond_to(:all_there?) }
-
   it 'should return an enumerable result' do
     expect(subject.plural_sections).to be_an Array
   end

--- a/test_site/html/home.htm
+++ b/test_site/html/home.htm
@@ -8,34 +8,29 @@
     }
 
     function load() {
-      //create the link
+      //create the link with text/class/href properties
       slow_link = document.createElement("a");
-      //create a text node
-      some_text = document.createTextNode("slow link");
-      //set the link's href
+      slow_link.innerText = "slow link";
+      slow_link.setAttribute("class", "slow");
       slow_link.setAttribute('href', 'slowly.htm');
-      //set the link's class
-      slow_link.setAttribute('class', 'slow');
-      //add the text to the link
-      slow_link.appendChild(some_text);
       //get the element that we're going to add the link to
       dumping_ground = document.getElementById('dumping_ground');
-      //wait for ~2s and then add the links
-      var t1 = setTimeout("dumping_ground.appendChild(slow_link);", 1750);
-      var t2 = setTimeout("document.getElementById('will_become_visible').style.display='block';", 1750);
-      var t3 = setTimeout("document.getElementById('will_become_invisible').style.display='none';", 1750);
-      var t4 = setTimeout("document.getElementById('will_become_nonexistent').remove();", 1750);
-      var t5 = setTimeout("document.getElementById('link_container_will_become_nonexistent').remove();", 1750);
+      //wait for a short while then add the links
+      setTimeout("dumping_ground.appendChild(slow_link);", 1150);
+      setTimeout("document.getElementById('will_become_visible').style.display='block';", 1150);
+      setTimeout("document.getElementById('will_become_invisible').style.display='none';", 1150);
+      setTimeout("document.getElementById('will_become_nonexistent').remove();", 1150);
+      setTimeout("document.getElementById('link_container_will_become_nonexistent').remove();", 1150);
 
-      var slow_section = document.createElement("div");
+      slow_section = document.createElement("div");
       slow_section.className = 'slow-section first';
-      var slow_section2 = document.createElement("div");
+      slow_section2 = document.createElement("div");
       slow_section2.className = 'slow-section second';
       setTimeout(function() {
         [slow_section, slow_section2].forEach(function(item) {
           dumping_ground.appendChild(item);
         });
-      }, 1750)
+      }, 1150)
     }
     window.onload = load;
     </script>

--- a/test_site/pages/dynamic_page.rb
+++ b/test_site/pages/dynamic_page.rb
@@ -9,4 +9,8 @@ class DynamicPage < SitePrism::Page
   end
 
   element :dummy_element_two, '.third'
+  # missing_element does not exist
+  #element :missing_element, '.not-present'
+
+  #expected_elements :missing_element, :dummy_section
 end

--- a/test_site/pages/dynamic_page.rb
+++ b/test_site/pages/dynamic_page.rb
@@ -9,8 +9,4 @@ class DynamicPage < SitePrism::Page
   end
 
   element :dummy_element_two, '.third'
-  # missing_element does not exist
-  #element :missing_element, '.not-present'
-
-  #expected_elements :missing_element, :dummy_section
 end

--- a/test_site/pages/no_title.rb
+++ b/test_site/pages/no_title.rb
@@ -6,4 +6,8 @@ class NoTitle < SitePrism::Page
 
   element :element_without_selector
   elements :elements_without_selector
+  element :message, 'p'
+  element :missing_message, 'br'
+
+  expected_elements :message, :missing_message
 end


### PR DESCRIPTION
The Small (But wide-affecting), plan here is to standardise the 4/6 (2 will be removed in the other PR), DSL defined meta-programmed methods, so they all take one single enumerable option (Which is hash-ified, standardised and then passed to capybara)

Caveats
- Not standardised the 2 methods being removed (`wait_for` and `wait_for_no`)
- I've left a warning in for people configuring SitePrism, not sure yet whether to remove this fully or not.

NB: I also did a small amount of spec tidying as there were some old TODO items which I just wanted to clear out of the way.