### PR TITLE
Simplecov config

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+SimpleCov.start do
+  add_group 'Features', 'features'
+  add_group 'Specs', 'spec'
+  add_group 'Code', 'lib'
+end
+
+SimpleCov.minimum_coverage 92
+SimpleCov.refuse_coverage_drop

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,14 @@
 unless ENV['CI']
   require 'simplecov'
   require 'dotenv'
-  SimpleCov.start
+  SimpleCov.start do
+    add_group 'Features', 'features'
+    add_group 'Specs', 'spec'
+    add_group 'Code', 'lib'
+  end
+  # Features are currently at 94% on master (Sep 2018)
+  SimpleCov.minimum_coverage 92
+  SimpleCov.refuse_coverage_drop
   Dotenv.load('.env')
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,14 +3,6 @@
 unless ENV['CI']
   require 'simplecov'
   require 'dotenv'
-  SimpleCov.start do
-    add_group 'Features', 'features'
-    add_group 'Specs', 'spec'
-    add_group 'Code', 'lib'
-  end
-  # Features are currently at 94% on master (Sep 2018)
-  SimpleCov.minimum_coverage 92
-  SimpleCov.refuse_coverage_drop
   Dotenv.load('.env')
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,6 @@
 
 unless ENV['CI']
   require 'simplecov'
-  SimpleCov.start do
-    add_group 'Features', 'features'
-    add_group 'Specs', 'spec'
-    add_group 'Code', 'lib'
-  end
-  # Spec is currently at 97.7% on master (Sep 2018)
-  SimpleCov.minimum_coverage 96
-  SimpleCov.refuse_coverage_drop
 end
 
 require 'capybara'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-unless ENV['CI']
-  require 'simplecov'
-end
+require 'simplecov' unless ENV['CI']
 
 require 'capybara'
 require 'capybara/dsl'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,14 @@
 
 unless ENV['CI']
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_group 'Features', 'features'
+    add_group 'Specs', 'spec'
+    add_group 'Code', 'lib'
+  end
+  # Spec is currently at 97.7% on master (Sep 2018)
+  SimpleCov.minimum_coverage 96
+  SimpleCov.refuse_coverage_drop
 end
 
 require 'capybara'


### PR DESCRIPTION
Use centralised location for all config options (Not many at the moment)

Enforce a minimum pass-rate of 92% and no decrease in coverage (This will be upped in time)