### PR TITLE
Eliminate cause of warnings

### DIFF
--- a/lib/site_prism/page.rb
+++ b/lib/site_prism/page.rb
@@ -21,7 +21,7 @@ module SitePrism
       end
 
       def url_matcher
-        @url_matcher || url
+        @url_matcher ||= url
       end
     end
 
@@ -31,7 +31,7 @@ module SitePrism
     # in order, with the default "displayed?" validation being ran _FIRST_
 
     def page
-      @page || Capybara.current_session
+      @page ||= Capybara.current_session
     end
 
     # Loads the page.


### PR DESCRIPTION
I have a project that makes extensive use of site_prism.  It is currently running on ruby-2.5.5.

I receive tons of warnings of this form:

/Users/nate/.rvm/gems/ruby-2.5.1/gems/site_prism-3.0/lib/site_prism/page.rb:34: warning: instance variable @page not initialized

And for reference $-W is at 1.  This is not with verbose logging on, this is with default logging level set.

I did update to ruby 2.3.0, and ran all tests successfully.  The update to 2.3 was only due to it being the easiest path to bundle installing.

closes #345 