### PR TITLE
Improved Test runtime by ~20%

### DIFF
--- a/features/implicit_waiting.feature
+++ b/features/implicit_waiting.feature
@@ -4,7 +4,7 @@ Feature: Waiting for Elements Implicitly
   In order to interact with the element once it is ready
 
   Background:
-    When I navigate to the home page
+    When I navigate to the slow page
 
   Scenario: Element is Automatically Waited For
     Then the slow element is waited for

--- a/features/section_explicit_waiting.feature
+++ b/features/section_explicit_waiting.feature
@@ -3,14 +3,13 @@ Feature: Waiting for a Section
   I want to be able to explicitly wait for a section
   In order to interact with the element once it is ready
 
-  Background:
-    When I navigate to the home page
-
   Scenario: Wait for Section - Positive - Overridden Timeout
-    When I wait for the section that takes a while to appear
+    When I navigate to the slow page
+    And I wait for the section that takes a while to appear
     Then the slow section appears
 
   Scenario: Wait for Section - Negative - Overridden Timeout
+    When I navigate to the home page
     Then an exception is raised when I wait for a section that won't appear
 
   Scenario: Wait for Section Invisibility - Positive - Default Timeout
@@ -25,7 +24,9 @@ Feature: Waiting for a Section
 
   @slow-test
   Scenario: Wait for Section Invisibility - Negative - Default Timeout
+    When I navigate to the home page
     Then an error is raised when waiting for the section to vanish
 
   Scenario: Wait for Section Invisibility - Negative - Overridden Timeout
+    When I navigate to the home page
     Then an error is raised when waiting a new time for the section to vanish

--- a/features/step_definitions/implicit_waiting_steps.rb
+++ b/features/step_definitions/implicit_waiting_steps.rb
@@ -4,60 +4,60 @@
 
 Then('the slow element is waited for') do
   start_time = Time.now
-  @test_site.home.slow_element
+  @test_site.slow.last_link
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the slow elements are waited for') do
   start_time = Time.now
-  @test_site.home.slow_elements(minimum: 1)
+  @test_site.slow.even_links(minimum: 1)
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the slow section is waited for') do
   start_time = Time.now
-  @test_site.home.slow_section(count: 1)
+  @test_site.slow.first_section(count: 1)
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the slow sections are waited for') do
   start_time = Time.now
-  @test_site.home.slow_sections(count: 2)
+  @test_site.slow.all_sections(count: 2)
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the boolean test for a slow element is waited for') do
   start_time = Time.now
 
-  expect(@test_site.home.has_slow_element?).to be true
+  expect(@test_site.slow.has_last_link?).to be true
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the boolean test for slow elements are waited for') do
   start_time = Time.now
 
-  expect(@test_site.home.has_slow_elements?).to be true
+  expect(@test_site.slow.has_even_links?).to be true
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the boolean test for a slow section is waited for') do
   start_time = Time.now
 
-  expect(@test_site.home.has_slow_section?(count: 1)).to be true
+  expect(@test_site.slow.has_first_section?(count: 1)).to be true
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end
 
 Then('the boolean test for slow sections are waited for') do
   start_time = Time.now
 
-  expect(@test_site.home.has_slow_sections?(count: 2)).to be true
+  expect(@test_site.slow.has_all_sections?(count: 2)).to be true
 
-  expect(Time.now - start_time).to be_between(0.9, 1.1)
+  expect(Time.now - start_time).to be_between(0.2, 0.4)
 end

--- a/features/step_definitions/section_explicit_waiting_steps.rb
+++ b/features/step_definitions/section_explicit_waiting_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 When('I wait for the section that takes a while to appear') do
-  @test_site.home.slow_section(wait: 1)
+  @test_site.slow.first_section(wait: 1)
 end
 
 When('I wait for the section that takes a while to vanish') do
@@ -27,7 +27,7 @@ When('I wait an overridden time for the section to vanish') do
 end
 
 Then('the slow section appears') do
-  expect(@test_site.home).to have_slow_section
+  expect(@test_site.slow).to have_first_section
 end
 
 Then('an error is raised when waiting a new time for the section to vanish') do

--- a/features/support/pages/home.rb
+++ b/features/support/pages/home.rb
@@ -33,7 +33,7 @@ class Home < SitePrism::Page
   section :container, Container, '#container'
   section :nonexistent_section, Blank, 'input#nonexistent'
   section :removing_section, Blank, 'input#will_become_nonexistent'
-  section :slow_section, Blank, 'div.first.slow-section'
+  # section :slow_section, Blank, 'div.first.slow-section'
   section :vanishing_section, Blank, 'input#will_become_invisible'
 
   # section groups

--- a/test_site/home.htm
+++ b/test_site/home.htm
@@ -23,16 +23,6 @@
             dumping_ground.append(" ");
           });
         }, 950);
-
-        slow_section = document.createElement("div");
-        slow_section.className = 'slow-section first';
-        slow_section2 = document.createElement("div");
-        slow_section2.className = 'slow-section second';
-        setTimeout(function() {
-          [slow_section, slow_section2].forEach(function(item) {
-            dumping_ground.appendChild(item);
-          });
-        }, 950)
       }
       window.onload = load;
     </script>


### PR DESCRIPTION
- Remove the 2 slow sections that were injected into the home page
- Use the slow page for tests that require validating slow items appear (This is better optimised and faster than the legacy homepage items
- Tidy up code and standardise tests