### PR TITLE
2019 generic bump

### DIFF
--- a/.cucumber-timings
+++ b/.cucumber-timings
@@ -2,8 +2,8 @@ Area - # Scenarios - Timings
 
 This needs to be re-hashed and re-verified
 
-all - 84 Scenarios - ~47s
-element/elements/element_explicit_waiting - 27 Scenarios - ~21s
-section/sections/section_explicit_waiting - 28 Scenarios - ~13s
-page/navigation/implicit_waiting - 20 Scenarios - ~15s
-iframe/malformed items - 9 Scenarios - ~3s
+all - 86 Scenarios - ~27s
+element/elements/element_explicit_waiting - 23 Scenarios - ~12s
+section/sections/section_explicit_waiting - 28 Scenarios - ~8s
+page/navigation/implicit_waiting - 26 Scenarios - ~9s
+iframe/malformed items - 9 Scenarios - ~2s

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,8 @@ AccessorMethodName:
   Enabled: false
 
 Style/RegexpLiteral:
-  Enabled: false
+  EnforcedStyle: slashes
+  AllowInnerSlashes: true
 
 BlockLength:
   Exclude:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2018, Nathaniel Ritmeyer & the SitePrism team
+Copyright (c) 2011-2019, Nathaniel Ritmeyer & the SitePrism team
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here's an overview of how SitePrism is designed to be used:
 
 class Home < SitePrism::Page
   set_url '/index.htm'
-  set_url_matcher /google.com\/?/
+  set_url_matcher(/google.com\/?/)
 
   element :search_field, 'input[name="q"]'
   element :search_button, 'button[name="btnK"]'
@@ -41,7 +41,7 @@ class Home < SitePrism::Page
 end
 
 class SearchResults < SitePrism::Page
-  set_url_matcher /google.com\/results\?.*/
+  set_url_matcher(/google.com\/results\?.*/)
 
   section :menu, MenuSection, '#gbx3'
   sections :search_results, SearchResultSection, '#results li'
@@ -318,7 +318,7 @@ URL matchers by it by calling `set_url_matcher`:
 
 ```ruby
 class Account < SitePrism::Page
-  set_url_matcher %r{/accounts/\d+}
+  set_url_matcher(/accounts/\d+/)
 end
 ```
 

--- a/low_spec.gemfile
+++ b/low_spec.gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'capybara', '< 3.0'
-gem 'selenium-webdriver', '< 3.9'
 gem 'nokogiri', '< 1.8'
+gem 'selenium-webdriver', '< 3.9'
 
 gemspec

--- a/low_spec.gemfile
+++ b/low_spec.gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 
 gem 'capybara', '< 3.0'
 gem 'selenium-webdriver', '< 3.9'
+gem 'nokogiri', '< 1.8'
 
 gemspec

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -23,12 +23,12 @@ SitePrism implements the Page Object Model pattern on top of Capybara."
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.5']
-  s.add_dependency 'capybara', ['>= 2.17', '< 4.0']
+  s.add_dependency 'capybara', ['>= 2.18', '< 4.0']
 
-  s.add_development_dependency 'cucumber', ['~> 3.0']
+  s.add_development_dependency 'cucumber', ['~> 3.1']
   s.add_development_dependency 'dotenv', ['~> 2.5']
-  s.add_development_dependency 'rake', ['~> 12.0']
-  s.add_development_dependency 'rspec', ['~> 3.6']
+  s.add_development_dependency 'rake', ['~> 12.3']
+  s.add_development_dependency 'rspec', ['~> 3.8']
   s.add_development_dependency 'rubocop', ['~> 0.60.0']
   s.add_development_dependency 'selenium-webdriver', ['~> 3.7']
   s.add_development_dependency 'simplecov', ['~> 0.16']

--- a/spec/site_prism/page_spec.rb
+++ b/spec/site_prism/page_spec.rb
@@ -177,7 +177,7 @@ is called before the matcher has been set" do
   describe '#displayed?' do
     context 'with a full string URL matcher' do
       class PageWithStringFullUrlMatcher < SitePrism::Page
-        set_url_matcher 'https://joe:bump@bla.org:443/foo?bar=baz&bar=boof#frag'
+        set_url_matcher('https://joe:bump@bla.org:443/foo?bar=baz&bar=boof#frag')
       end
 
       let(:page) { PageWithStringFullUrlMatcher.new }
@@ -255,7 +255,7 @@ is called before the matcher has been set" do
 
     context 'with a minimal URL matcher' do
       class PageWithStringMinimalUrlMatcher < SitePrism::Page
-        set_url_matcher '/foo'
+        set_url_matcher('/foo')
       end
 
       let(:page) { PageWithStringMinimalUrlMatcher.new }
@@ -289,7 +289,7 @@ is called before the matcher has been set" do
 
     context 'with a parameterized URL matcher' do
       class PageWithParameterizedUrlMatcher < SitePrism::Page
-        set_url_matcher '{scheme}:///foos{/id}'
+        set_url_matcher('{scheme}:///foos{/id}')
       end
 
       let(:page) { PageWithParameterizedUrlMatcher.new }
@@ -329,7 +329,7 @@ from the be_displayed matcher" do
 
     context 'with a bogus URL matcher' do
       class PageWithBogusFullUrlMatcher < SitePrism::Page
-        set_url_matcher this: "isn't a URL matcher"
+        set_url_matcher(this: "isn't a URL matcher")
       end
 
       let(:page) { PageWithBogusFullUrlMatcher.new }
@@ -344,7 +344,7 @@ from the be_displayed matcher" do
   describe '#url_matches' do
     context 'with a templated matcher' do
       class PageWithParameterizedUrlMatcher < SitePrism::Page
-        set_url_matcher '{scheme}:///foos{/id}'
+        set_url_matcher('{scheme}:///foos{/id}')
       end
 
       let(:page) { PageWithParameterizedUrlMatcher.new }
@@ -390,7 +390,7 @@ from the be_displayed matcher" do
 
     context 'with a bogus URL matcher' do
       class PageWithBogusFullUrlMatcher < SitePrism::Page
-        set_url_matcher this: "isn't a URL matcher"
+        set_url_matcher(this: "isn't a URL matcher")
       end
 
       let(:page) { PageWithBogusFullUrlMatcher.new }


### PR DESCRIPTION
Update dependencies for devs to higher ones
Update cucumber timings document
Add weak nokogiri restriction to `low_spec.gemfile`
Capybara minimum reqt is now `2.18` pending the removal of 2.x support.