### PR TITLE
Added support for negated existence matchers in RSpec

### DIFF
--- a/lib/site_prism/dsl.rb
+++ b/lib/site_prism/dsl.rb
@@ -154,6 +154,7 @@ module SitePrism
       def add_helper_methods(name, *find_args)
         create_existence_checker(name, *find_args)
         create_nonexistence_checker(name, *find_args)
+        create_rspec_existence_matchers(name) if defined?(RSpec)
         create_visibility_waiter(name, *find_args)
         create_invisibility_waiter(name, *find_args)
       end
@@ -163,6 +164,18 @@ module SitePrism
           create_error_method(proposed_method_name)
         else
           yield
+        end
+      end
+
+      def create_rspec_existence_matchers(element_name)
+        matcher = "has_#{element_name}?"
+        negated_matcher = "has_no_#{element_name}?"
+
+        RSpec::Matchers.define "have_#{element_name}" do |*args|
+          match { |actual| actual.public_send(matcher, *args) }
+          match_when_negated do |actual|
+            actual.public_send(negated_matcher, *args)
+          end
         end
       end
 

--- a/spec/site_prism/element_spec.rb
+++ b/spec/site_prism/element_spec.rb
@@ -16,10 +16,13 @@ describe 'Element' do
     it { is_expected.to respond_to(:wait_until_element_one_visible) }
     it { is_expected.to respond_to(:wait_until_element_one_invisible) }
 
+    it 'supports rspec existence matchers' do
+      expect(subject).to have_element_one
+    end
+
     it 'supports negated rspec existence matchers' do
-      expect(subject).not_to receive(:has_element_one?)
-      expect(subject).to receive(:has_no_element_one?).and_return true
-      expect(subject).not_to have_element_one
+      expect(subject).to receive(:has_no_element_two?).once.and_call_original
+      expect(subject).not_to have_element_two
     end
 
     describe '#all_there?' do

--- a/spec/site_prism/element_spec.rb
+++ b/spec/site_prism/element_spec.rb
@@ -16,6 +16,12 @@ describe 'Element' do
     it { is_expected.to respond_to(:wait_until_element_one_visible) }
     it { is_expected.to respond_to(:wait_until_element_one_invisible) }
 
+    it 'supports negated rspec existence matchers' do
+      expect(subject).not_to receive(:has_element_one?)
+      expect(subject).to receive(:has_no_element_one?).and_return true
+      expect(subject).not_to have_element_one
+    end
+
     describe '#all_there?' do
       subject { page.all_there? }
 


### PR DESCRIPTION
This adds support for negated existence matchers in RSpec. E.g.:
```ruby
class TestPage < SitePrism::Page
  element :heading, 'h1'
end
expect(page).not_to have_heading # => Calls now #has_no_heading?
```

This also worked before however it used the `#has_<element>?` methods for that case. This caused capybara to wait until the element **is** visible. But as in the example above i expect the element to be **not** visible this always waits until the max wait timeout is reached.

This change automatically calls the `#has_no_<element>?` method when the RSpec expectation is negated.