### PR TITLE
Remove outdated RSpec syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,6 @@ Or even run some tests ...
 ```ruby
 expect(@friends_page.names.map { |name| name.text }).to eq(['Alice', 'Bob', 'Fred'])
 expect(@friends_page.names.size).to eq(3)
-expect(@friends_page).to have(3).names
 ```
 
 #### Testing for the existence of the element collection


### PR DESCRIPTION
The cardinality matchers were removed in RSpec 3.0.0.beta1. They're available using https://github.com/rspec/rspec-collection_matchers, but since that's not available by default, it might cause confusion to mention it here.